### PR TITLE
refactor: update process handling to return stdout/err

### DIFF
--- a/src/catter/core/app_runner.cc
+++ b/src/catter/core/app_runner.cc
@@ -93,7 +93,7 @@ private:
     const js::CatterRuntime* runtime = nullptr;
 };
 
-int64_t inject(const js::CatterConfig& config) {
+data::process_result inject(const js::CatterConfig& config) {
     if(config.buildSystemCommand.empty()) {
         throw cpptrace::runtime_error("buildSystemCommand must not be empty");
     }
@@ -117,7 +117,7 @@ int64_t inject(const js::CatterConfig& config) {
     return session.run(std::move(session_plan));
 }
 
-int64_t execute_service(ipc::ServiceMode mode, const js::CatterConfig& config) {
+data::process_result execute_service(ipc::ServiceMode mode, const js::CatterConfig& config) {
     switch(mode) {
         case ipc::ServiceMode::INJECT: {
             return inject(config);
@@ -152,8 +152,12 @@ void run(const core::CatterConfig& config) {
         return;
     }
 
+    auto process_result = execute_service(config.mode->mode, js_config);
+
     js::on_finish(js::ProcessResult{
-        .code = execute_service(config.mode->mode, js_config),
+        .code = process_result.code,
+        .stdOut = std::move(process_result.std_out),
+        .stdErr = std::move(process_result.std_err),
     });
 }
 

--- a/src/catter/core/session.cc
+++ b/src/catter/core/session.cc
@@ -18,7 +18,7 @@
 
 namespace catter {
 
-int64_t Session::run(RunPlan run_plan) {
+data::process_result Session::run(RunPlan run_plan) {
 #ifndef _WIN32
     if(std::filesystem::exists(config::ipc::pipe_name())) {
         std::filesystem::remove(config::ipc::pipe_name());
@@ -78,9 +78,9 @@ kota::task<void> Session::loop(ClientAcceptor acceptor) {
     co_return;
 }
 
-kota::task<int64_t> Session::spawn(std::string executable,
-                                   std::vector<std::string> args,
-                                   std::string cwd) {
+kota::task<data::process_result> Session::spawn(std::string executable,
+                                                std::vector<std::string> args,
+                                                std::string cwd) {
     // for exception safety: ensure acceptor is stopped when spawn exits, since spawn failure should
     // prevent the session from running
     auto guard = util::make_guard([&]() noexcept {
@@ -98,9 +98,9 @@ kota::task<int64_t> Session::spawn(std::string executable,
         .args = args,
         .cwd = cwd,
         .creation = {.windows_hide = true, .windows_verbatim_arguments = true},
-        .streams = {kota::process::stdio::ignore(),
-                     kota::process::stdio::ignore(),
-                     kota::process::stdio::ignore()}
+        .streams = {kota::process::stdio::inherit(),
+                     kota::process::stdio::pipe(false, true),
+                     kota::process::stdio::pipe(false, true)}
     };
 
     std::string args_str;
@@ -113,20 +113,7 @@ kota::task<int64_t> Session::spawn(std::string executable,
              cwd,
              args_str);
 
-    auto spawn_ret = kota::process::spawn(opts, kota::event_loop::current());
-    if(!spawn_ret) {
-        throw cpptrace::runtime_error(
-            std::format("process spawn failed: {}", spawn_ret.error().message()));
-    }
-
-    auto exit_status = co_await spawn_ret->proc.wait();
-    if(exit_status.has_error()) {
-        throw cpptrace::runtime_error(
-            std::format("process wait failed: {}", exit_status.error().message()));
-    }
-
-    auto [ret, signal] = *exit_status;
-    co_return ret;
+    co_return co_await capture_process_result(make_process_event(opts));
 }
 
 }  // namespace catter

--- a/src/catter/core/session.h
+++ b/src/catter/core/session.h
@@ -71,16 +71,17 @@ public:
     /**
      * Run the session with the given run plan.
      * @param run_plan The run plan containing the launch plan and service factory.
-     * @return The exit code of the spawned process.
+     * @return The result of the process execution, including exit status and captured
+     * stdout/stderr.
      */
-    int64_t run(RunPlan run_plan);
+    data::process_result run(RunPlan run_plan);
 
 private:
     kota::task<void> loop(ClientAcceptor acceptor);
 
-    kota::task<int64_t> spawn(std::string executable,
-                              std::vector<std::string> args,
-                              std::string cwd);
+    kota::task<data::process_result> spawn(std::string executable,
+                                           std::vector<std::string> args,
+                                           std::string cwd);
 
     std::unique_ptr<PipeAcceptor> acc = nullptr;
 };

--- a/tests/integration/test/catter-proxy.cc
+++ b/tests/integration/test/catter-proxy.cc
@@ -112,9 +112,12 @@ int run_case(std::vector<std::string> args, std::string cwd = {}) {
         .args = std::move(args),
     };
     auto session_plan = Session::make_run_plan(std::move(launch_plan), ServiceImpl::Factory{});
-    auto ret = static_cast<int>(session.run(std::move(session_plan)));
-    LOG_INFO("Session finished with exit code {}", ret);
-    return ret;
+    auto process_result = session.run(std::move(session_plan));
+    LOG_INFO("Session finished with exit code {} and stdout: `{}` and stderr: `{}`",
+             process_result.code,
+             log::escape(process_result.std_out),
+             log::escape(process_result.std_err));
+    return process_result.code;
 }
 
 }  // namespace


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/clice-io/codesmith/catter/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Process execution now captures and returns complete output (stdout and stderr) alongside exit codes, improving visibility into service behavior.

* **Refactor**
  * Restructured service execution paths to propagate full process results instead of only exit status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->