### PR TITLE
refactor: replace data::output_mode with Session::StdioMode

### DIFF
--- a/src/catter/core/runtime_driver.cc
+++ b/src/catter/core/runtime_driver.cc
@@ -18,10 +18,10 @@
 
 namespace catter::core {
 namespace {
-data::output_mode to_process_output_mode(js::CatterOptions::OutputMode output_mode) {
+Session::output_mode to_process_output_mode(js::CatterOptions::OutputMode output_mode) {
     switch(output_mode) {
-        case js::CatterOptions::OutputMode::inherit: return data::output_mode::inherit;
-        case js::CatterOptions::OutputMode::capture: return data::output_mode::capture;
+        case js::CatterOptions::OutputMode::inherit: return Session::output_mode::inherit;
+        case js::CatterOptions::OutputMode::capture: return Session::output_mode::capture;
     }
 
     throw cpptrace::runtime_error("Unhandled catter output mode");

--- a/src/catter/core/runtime_driver.cc
+++ b/src/catter/core/runtime_driver.cc
@@ -18,10 +18,10 @@
 
 namespace catter::core {
 namespace {
-Session::output_mode to_process_output_mode(js::CatterOptions::OutputMode output_mode) {
+Session::StdioMode to_process_output_mode(js::CatterOptions::OutputMode output_mode) {
     switch(output_mode) {
-        case js::CatterOptions::OutputMode::inherit: return Session::output_mode::inherit;
-        case js::CatterOptions::OutputMode::capture: return Session::output_mode::capture;
+        case js::CatterOptions::OutputMode::inherit: return Session::StdioMode::inherit;
+        case js::CatterOptions::OutputMode::capture: return Session::StdioMode::capture;
     }
 
     throw cpptrace::runtime_error("Unhandled catter output mode");
@@ -124,7 +124,7 @@ public:
                        proxy_path.string(),
                        "-p", "0",
                        "--", },
-            .output_mode = to_process_output_mode(
+            .mode = to_process_output_mode(
                 config.options.output.value_or(js::CatterOptions::OutputMode::inherit)),
         };
         util::append_range_to_vector(launch_plan.args, config.buildSystemCommand);

--- a/src/catter/core/session.cc
+++ b/src/catter/core/session.cc
@@ -79,7 +79,7 @@ kota::task<void> Session::loop(ClientAcceptor acceptor) {
 kota::task<data::process_result> Session::spawn(std::string executable,
                                                 std::vector<std::string> args,
                                                 std::string cwd,
-                                                data::output_mode output_mode) {
+                                                output_mode output_mode) {
     // for exception safety: ensure acceptor is stopped when spawn exits, since spawn failure should
     // prevent the session from running
     auto guard = util::make_guard([&]() noexcept {
@@ -92,16 +92,6 @@ kota::task<data::process_result> Session::spawn(std::string executable,
         }
     });
 
-    kota::process::options opts{
-        .file = executable,
-        .args = args,
-        .cwd = cwd,
-        .creation = {.windows_hide = true, .windows_verbatim_arguments = true},
-        .streams = {kota::process::stdio::inherit(),
-                     kota::process::stdio::pipe(false, true),
-                     kota::process::stdio::pipe(false, true)}
-    };
-
     std::string args_str;
     for(const auto& arg: args) {
         args_str += std::format("{} ", arg);
@@ -112,7 +102,24 @@ kota::task<data::process_result> Session::spawn(std::string executable,
              cwd,
              args_str);
 
-    co_return co_await capture_process_result(make_process_event(opts), output_mode);
+    kota::process::options opts{
+        .file = executable,
+        .args = args,
+        .cwd = cwd,
+        .creation = {.windows_hide = true, .windows_verbatim_arguments = true},
+        .streams = {kota::process::stdio::inherit(),
+                     kota::process::stdio::pipe(false, true),
+                     kota::process::stdio::pipe(false, true)}
+    };
+
+    switch(output_mode) {
+        case output_mode::inherit:
+            co_return co_await capture_process_result(make_process_event(opts), stdout, stderr);
+        case output_mode::capture:
+            co_return co_await capture_process_result(make_process_event(opts), nullptr, nullptr);
+    }
+
+    std::abort();
 }
 
 }  // namespace catter

--- a/src/catter/core/session.cc
+++ b/src/catter/core/session.cc
@@ -40,7 +40,7 @@ kota::task<data::process_result> Session::run(RunPlan run_plan) {
     auto spawn_task = this->spawn(std::move(run_plan.launch_plan.executable),
                                   std::move(run_plan.launch_plan.args),
                                   std::move(run_plan.launch_plan.cwd),
-                                  run_plan.launch_plan.output_mode);
+                                  run_plan.launch_plan.mode);
 
     auto [_, process_result] = co_await kota::when_all{std::move(loop_task), std::move(spawn_task)};
     co_return std::move(process_result);
@@ -79,7 +79,7 @@ kota::task<void> Session::loop(ClientAcceptor acceptor) {
 kota::task<data::process_result> Session::spawn(std::string executable,
                                                 std::vector<std::string> args,
                                                 std::string cwd,
-                                                output_mode output_mode) {
+                                                StdioMode mode) {
     // for exception safety: ensure acceptor is stopped when spawn exits, since spawn failure should
     // prevent the session from running
     auto guard = util::make_guard([&]() noexcept {
@@ -112,10 +112,10 @@ kota::task<data::process_result> Session::spawn(std::string executable,
                      kota::process::stdio::pipe(false, true)}
     };
 
-    switch(output_mode) {
-        case output_mode::inherit:
+    switch(mode) {
+        case StdioMode::inherit:
             co_return co_await capture_process_result(make_process_event(opts), stdout, stderr);
-        case output_mode::capture:
+        case StdioMode::capture:
             co_return co_await capture_process_result(make_process_event(opts), nullptr, nullptr);
     }
 

--- a/src/catter/core/session.h
+++ b/src/catter/core/session.h
@@ -38,7 +38,7 @@ public:
     using PipeAcceptor = kota::acceptor<kota::pipe>;
     using ClientAcceptor = kota::function<kota::task<void>(data::ipcid_t, kota::pipe&&)>;
 
-    enum class output_mode : uint8_t {
+    enum class StdioMode : uint8_t {
         inherit,
         capture,
     };
@@ -47,7 +47,7 @@ public:
         std::string cwd;
         std::string executable;
         std::vector<std::string> args;
-        output_mode output_mode;
+        StdioMode mode;
     };
 
     struct RunPlan {
@@ -88,7 +88,7 @@ private:
     kota::task<data::process_result> spawn(std::string executable,
                                            std::vector<std::string> args,
                                            std::string cwd,
-                                           output_mode output_mode);
+                                           StdioMode mode);
 
     std::unique_ptr<PipeAcceptor> acc = nullptr;
 };

--- a/src/catter/core/session.h
+++ b/src/catter/core/session.h
@@ -38,11 +38,16 @@ public:
     using PipeAcceptor = kota::acceptor<kota::pipe>;
     using ClientAcceptor = kota::function<kota::task<void>(data::ipcid_t, kota::pipe&&)>;
 
+    enum class output_mode : uint8_t {
+        inherit,
+        capture,
+    };
+
     struct ProcessLaunchPlan {
         std::string cwd;
         std::string executable;
         std::vector<std::string> args;
-        data::output_mode output_mode = data::output_mode::inherit;
+        output_mode output_mode;
     };
 
     struct RunPlan {
@@ -83,7 +88,7 @@ private:
     kota::task<data::process_result> spawn(std::string executable,
                                            std::vector<std::string> args,
                                            std::string cwd,
-                                           data::output_mode output_mode);
+                                           output_mode output_mode);
 
     std::unique_ptr<PipeAcceptor> acc = nullptr;
 };

--- a/src/common/util/data.h
+++ b/src/common/util/data.h
@@ -23,11 +23,6 @@ struct process_result {
     std::string std_err{};
 };
 
-enum class output_mode : uint8_t {
-    inherit,
-    capture,
-};
-
 struct action {
     enum : uint8_t {
         DROP,    // Do not execute the command

--- a/src/common/util/kotatsu.h
+++ b/src/common/util/kotatsu.h
@@ -70,13 +70,4 @@ inline kota::task<data::process_result> capture_process_result(process_event pro
         .std_err = stderr_proxy.output(),
     };
 }
-
-inline kota::task<data::process_result> capture_process_result(process_event proc_event,
-                                                               data::output_mode output_mode) {
-    const bool forward_output = output_mode == data::output_mode::inherit;
-    co_return co_await capture_process_result(std::move(proc_event),
-                                              forward_output ? stdout : nullptr,
-                                              forward_output ? stderr : nullptr);
-}
-
 }  // namespace catter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized how process I/O modes are represented and passed through the session runtime for clearer behavior.
  * Streamlined the process-result capture API to use explicit output sinks, reducing ambiguity.
  * Improved logging around process launch arguments and made output routing more explicit for more predictable I/O handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->