### PR TITLE
refactor: consolidate type.h by including bridge.h and improve HTTP response structure

### DIFF
--- a/api/catter-c/capi.d.ts
+++ b/api/catter-c/capi.d.ts
@@ -255,7 +255,7 @@ export type RawHttpResponse = {
   ok: boolean;
   url: string;
   body: string;
-  rawHeaders: string[];
+  headers: Record<string, string>;
 };
 
 export function http_client_create(): number;

--- a/api/src/http.ts
+++ b/api/src/http.ts
@@ -24,7 +24,6 @@ export class Response {
   readonly ok: boolean;
   readonly url: string;
   readonly body: string;
-  readonly rawHeaders: Array<[string, string]>;
   readonly headers: Record<string, string>;
 
   constructor(raw: {
@@ -32,14 +31,13 @@ export class Response {
     ok: boolean;
     url: string;
     body: string;
-    rawHeaders: string[];
+    headers: Record<string, string>;
   }) {
     this.status = raw.status;
     this.ok = raw.ok;
     this.url = raw.url;
     this.body = raw.body;
-    this.rawHeaders = pairs(raw.rawHeaders);
-    this.headers = normalizeHeaders(this.rawHeaders);
+    this.headers = raw.headers;
   }
 
   text(): string {
@@ -231,23 +229,4 @@ function flattenHeaders(headers: HeaderInit | undefined): string[] {
   }
 
   return Object.entries(headers).flatMap(([name, value]) => [name, value]);
-}
-
-function pairs(flatHeaders: string[]): Array<[string, string]> {
-  const result: Array<[string, string]> = [];
-  for (let i = 0; i + 1 < flatHeaders.length; i += 2) {
-    result.push([flatHeaders[i], flatHeaders[i + 1]]);
-  }
-  return result;
-}
-
-function normalizeHeaders(
-  headers: Array<[string, string]>,
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [name, value] of headers) {
-    const key = name.toLowerCase();
-    result[key] = key in result ? `${result[key]}, ${value}` : value;
-  }
-  return result;
 }

--- a/src/catter/core/js/capi/bridge.h
+++ b/src/catter/core/js/capi/bridge.h
@@ -1,0 +1,325 @@
+#pragma once
+
+/**
+ * @file bridge.h
+ * @brief Generic conversion bridge between C++ values and QuickJS values.
+ *
+ * This module centralizes the policy used by the C API data model to cross the C++/JavaScript
+ * boundary. `Bridge<T>` provides the conversion entry points and delegates ordinary values to the
+ * qjs wrappers. Specialized bridges add support for reflected structs, string-backed enums,
+ * vectors, and tagged unions.
+ *
+ * Reflected structs are converted field by field. Optional fields accept `undefined` when reading
+ * and are omitted when empty during writing. A reflected type may define a nested `name_mapper`
+ * with a static `map` function to translate C++ field names to JavaScript property names.
+ * `TaggedUnion` serializes each alternative as an object with a string `type` discriminator and
+ * uses the reflected `Tag` specialization as its payload schema.
+ *
+ * Domain types should keep only their schema and local customization in their own headers, then
+ * use `make_reflected_object` and `to_reflected_object` for object conversion.
+ */
+
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <fcntl.h>
+#include <cpptrace/exceptions.hpp>
+#include <kota/support/type_traits.h>
+#include <kota/meta/enum.h>
+#include <kota/meta/struct.h>
+
+#include "../qjs.h"
+#include "util/enum.h"
+
+namespace catter::js {
+
+template <typename T>
+struct Bridge;
+
+template <typename T>
+T make_reflected_object(qjs::Object object);
+
+template <typename T>
+qjs::Object to_reflected_object(JSContext* ctx, const T& value);
+
+namespace detail {
+
+template <typename E>
+constexpr E enum_value(std::string_view name) {
+    if(auto val = kota::meta::enum_value<E>(name); val.has_value()) {
+        return *val;
+    }
+    throw cpptrace::runtime_error(std::format("Invalid enum value name: {}", name));
+}
+
+template <typename E>
+constexpr std::string_view enum_name(E value) {
+    return kota::meta::enum_name(value, "unknown");
+}
+
+template <typename E>
+std::vector<E> enum_values(const std::vector<std::string>& names) {
+    std::vector<E> values;
+    values.reserve(names.size());
+    for(const auto& name: names) {
+        values.push_back(enum_value<E>(name));
+    }
+    return values;
+}
+
+template <typename E>
+std::vector<std::string> enum_names(const std::vector<E>& values) {
+    std::vector<std::string> names;
+    names.reserve(values.size());
+    for(const auto& value: values) {
+        names.push_back(std::string(enum_name(value)));
+    }
+    return names;
+}
+
+template <typename T>
+T read_property(const qjs::Object& object, std::string_view property_name) {
+    if constexpr(kota::is_optional_v<T>) {
+        using value_type = typename T::value_type;
+        auto prop_val = object[std::string(property_name)];
+        if(!prop_val.is_undefined()) {
+            return Bridge<value_type>::from_js(prop_val);
+        } else {
+            return std::nullopt;
+        }
+    } else {
+        return Bridge<T>::from_js(object[std::string(property_name)]);
+    }
+}
+
+template <typename T>
+void write_property(qjs::Object& object,
+                    std::string_view property_name,
+                    JSContext* ctx,
+                    const T& value) {
+    if constexpr(kota::is_optional_v<T>) {
+        using value_type = typename T::value_type;
+        if(value.has_value()) {
+            object.set_property(std::string(property_name), Bridge<value_type>::to_js(ctx, *value));
+        }
+    } else {
+        object.set_property(std::string(property_name), Bridge<T>::to_js(ctx, value));
+    }
+}
+}  // namespace detail
+
+template <auto E>
+    requires std::is_enum_v<std::decay_t<decltype(E)>>
+struct Tag {
+    bool operator== (const Tag& other) const = default;
+};
+
+template <auto... ES>
+concept EnumValues =
+    (std::is_enum_v<std::decay_t<decltype(ES)>> && ...) &&
+    (std::same_as<std::decay_t<decltype(ES)>, std::decay_t<decltype((ES, ...))>> && ...);
+
+template <auto... Es>
+    requires EnumValues<Es...>
+struct TaggedUnion;
+
+#define TAG                                                                                        \
+    template <>                                                                                    \
+    struct Tag
+
+template <auto... Es>
+    requires EnumValues<Es...>
+struct TaggedUnion : public std::variant<Tag<Es>...> {
+    using TagType = std::common_type_t<std::decay_t<decltype(Es)>...>;
+    using std::variant<Tag<Es>...>::variant;
+    TaggedUnion() = default;
+    TaggedUnion(const TaggedUnion&) = default;
+    TaggedUnion(TaggedUnion&&) = default;
+    TaggedUnion& operator= (const TaggedUnion&) = default;
+    TaggedUnion& operator= (TaggedUnion&&) = default;
+
+    static TaggedUnion make(qjs::Object object) {
+        return Bridge<TaggedUnion>::from_js(qjs::Value::from(object));
+    }
+
+    qjs::Object to_object(JSContext* ctx) const {
+        return Bridge<TaggedUnion>::to_js(ctx, *this);
+    }
+
+    std::variant<Tag<Es>...>& variant() {
+        return static_cast<std::variant<Tag<Es>...>&>(*this);
+    }
+
+    const std::variant<Tag<Es>...>& variant() const {
+        return static_cast<const std::variant<Tag<Es>...>&>(*this);
+    }
+
+    template <typename V>
+    decltype(auto) visit(V&& visitor) const {
+        return std::visit(std::forward<V>(visitor), this->variant());
+    }
+
+    template <typename V>
+    decltype(auto) visit(V&& visitor) {
+        return std::visit(std::forward<V>(visitor), this->variant());
+    }
+
+    TagType type() const {
+        return visit([]<auto E>(const Tag<E>&) -> TagType { return E; });
+    }
+
+    template <auto E>
+    decltype(auto) get_if() {
+        return std::get_if<Tag<E>>(&this->variant());
+    }
+
+    template <auto E>
+    decltype(auto) get_if() const {
+        return std::get_if<Tag<E>>(&this->variant());
+    }
+
+    template <auto E>
+    decltype(auto) get() {
+        return std::get<Tag<E>>(this->variant());
+    }
+
+    template <auto E>
+    decltype(auto) get() const {
+        return std::get<Tag<E>>(this->variant());
+    }
+
+    bool operator== (const TaggedUnion& other) const {
+        return this->visit([&]<typename T>(const T& tag) -> bool {
+            return other.visit([&]<typename U>(const U& other_tag) -> bool {
+                if constexpr(std::is_same_v<T, U>) {
+                    return tag == other_tag;
+                } else {
+                    return false;
+                }
+            });
+        });
+    }
+};
+
+template <typename T>
+struct Bridge {
+    static T from_js(const qjs::Value& value) {
+        return value.as<T>();
+    }
+
+    static auto to_js(JSContext* ctx, const T& value) {
+        return qjs::Value::from(ctx, value);
+    }
+};
+
+template <typename T>
+    requires kota::meta::reflectable_class<T>
+struct Bridge<T> {
+    static T from_js(const qjs::Value& value) {
+        return make_reflected_object<T>(value.as<qjs::Object>());
+    }
+
+    static auto to_js(JSContext* ctx, const T& value) {
+        return to_reflected_object(ctx, value);
+    }
+};
+
+template <typename T>
+    requires std::is_enum_v<T>
+struct Bridge<T> {
+    static T from_js(const qjs::Value& value) {
+        return detail::enum_value<T>(value.as<std::string>());
+    }
+
+    static auto to_js(JSContext* ctx, const T& value) {
+        return qjs::Value::from(ctx, std::string(detail::enum_name(value)));
+    }
+};
+
+template <typename T>
+    requires std::is_enum_v<T>
+struct Bridge<std::vector<T>> {
+    static std::vector<T> from_js(const qjs::Value& value) {
+        auto names = value.as<qjs::Array<std::string>>().as<std::vector<std::string>>();
+        return detail::enum_values<T>(names);
+    }
+
+    static auto to_js(JSContext* ctx, const std::vector<T>& vec) {
+        return qjs::Array<std::string>::from(ctx, detail::enum_names(vec));
+    }
+};
+
+template <typename T>
+struct Bridge<std::vector<T>> {
+    static std::vector<T> from_js(const qjs::Value& value) {
+        return value.as<qjs::Array<T>>().template as<std::vector<T>>();
+    }
+
+    static auto to_js(JSContext* ctx, const std::vector<T>& vec) {
+        return qjs::Array<T>::from(ctx, vec);
+    }
+};
+
+template <auto... Es>
+    requires EnumValues<Es...>
+struct Bridge<TaggedUnion<Es...>> {
+    using Union = TaggedUnion<Es...>;
+
+    static Union from_js(const qjs::Value& value) {
+        auto object = value.as<qjs::Object>();
+
+        auto tag = object["type"].as<std::string>();
+
+        return dispatch<typename Union::TagType>(tag, [&]<auto E>(in_place_enum<E>) -> Union {
+            return make_reflected_object<Tag<E>>(object);
+        });
+    }
+
+    static auto to_js(JSContext* ctx, const Union& union_value) {
+        return union_value.visit([&]<auto E>(const Tag<E>& tag) {
+            auto object = to_reflected_object(ctx, tag);
+            object.set_property("type", std::string(detail::enum_name(E)));
+            return object;
+        });
+    }
+};
+
+template <typename T>
+T make_reflected_object(qjs::Object object) {
+    T value{};
+    kota::meta::for_each(value, [&]<typename FieldType>(FieldType field) {
+        using field_type = std::remove_const_t<typename FieldType::type>;
+
+        if constexpr(requires { typename T::name_mapper; }) {
+            field.value() =
+                detail::read_property<field_type>(object, T::name_mapper::map(FieldType::name()));
+        } else {
+            field.value() = detail::read_property<field_type>(object, FieldType::name());
+        }
+    });
+    return value;
+}
+
+template <typename T>
+qjs::Object to_reflected_object(JSContext* ctx, const T& value) {
+    auto object = qjs::Object::empty_one(ctx);
+    kota::meta::for_each(value, [&]<typename FieldType>(FieldType field) {
+        if constexpr(requires { typename T::name_mapper; }) {
+            detail::write_property(object,
+                                   T::name_mapper::map(FieldType::name()),
+                                   ctx,
+                                   field.value());
+        } else {
+            detail::write_property(object, FieldType::name(), ctx, field.value());
+        }
+    });
+    return object;
+}
+
+}  // namespace catter::js

--- a/src/catter/core/js/capi/http.cc
+++ b/src/catter/core/js/capi/http.cc
@@ -5,8 +5,8 @@
 #include <vector>
 #include <kota/http/http.h>
 
+#include "bridge.h"
 #include "../apitool.h"
-#include "../qjs.h"
 
 namespace qjs = catter::qjs;
 
@@ -14,6 +14,14 @@ namespace {
 
 template <typename T>
 using JsTask = kota::task<T, qjs::Error>;
+
+struct HttpResponse {
+    int32_t status;
+    bool ok;
+    std::string url;
+    std::string body;
+    qjs::Object headers;
+};
 
 int64_t http_client_id_cnt = 1;
 std::unordered_map<int64_t, kota::http::client> http_clients;
@@ -48,21 +56,38 @@ std::vector<kota::http::header> read_headers(const qjs::Object& flat_headers) {
     return headers;
 }
 
-qjs::Object response_to_object(JSContext* ctx, const kota::http::response& response) {
-    auto result = qjs::Object::empty_one(ctx);
-    result.set_property("status", response.status);
-    result.set_property("ok", response.ok());
-    result.set_property("url", response.url);
-    result.set_property("body", response.text_copy());
+qjs::Object normalize_headers(JSContext* ctx, const std::vector<kota::http::header>& headers) {
+    std::unordered_map<std::string, std::string> normalized;
+    normalized.reserve(headers.size());
 
-    auto raw_headers = qjs::Array<std::string>::empty_one(ctx);
-    for(const auto& header: response.headers) {
-        raw_headers.push(header.name);
-        raw_headers.push(header.value);
+    for(const auto& header: headers) {
+        auto name = header.name;
+        std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) {
+            return std::tolower(c);
+        });
+
+        if(auto [entry, inserted] = normalized.try_emplace(std::move(name), header.value);
+           !inserted) {
+            entry->second.append(", ").append(header.value);
+        }
     }
-    result.set_property("rawHeaders", qjs::Object::from(std::move(raw_headers)));
 
+    qjs::Object result = qjs::Object::empty_one(ctx);
+    for(const auto& [name, value]: normalized) {
+        result.set_property(name, value);
+    }
     return result;
+}
+
+qjs::Object response_to_object(JSContext* ctx, const kota::http::response& response) {
+    return catter::js::to_reflected_object(ctx,
+                                           HttpResponse{
+                                               .status = response.status,
+                                               .ok = response.ok(),
+                                               .url = response.url,
+                                               .body = response.text_copy(),
+                                               .headers = normalize_headers(ctx, response.headers),
+                                           });
 }
 
 JsTask<qjs::Object> send_request(JSContext* ctx,

--- a/src/catter/core/js/capi/type.h
+++ b/src/catter/core/js/capi/type.h
@@ -1,304 +1,7 @@
 #pragma once
-#include <cstdint>
-#include <format>
-#include <optional>
-#include <string>
-#include <string_view>
-#include <type_traits>
-#include <utility>
-#include <variant>
-#include <vector>
-#include <fcntl.h>
-#include <cpptrace/exceptions.hpp>
-#include <kota/support/type_traits.h>
-#include <kota/meta/enum.h>
-#include <kota/meta/struct.h>
-
-#include "../qjs.h"
-#include "util/enum.h"
+#include "bridge.h"
 
 namespace catter::js {
-
-namespace detail {
-template <typename T>
-struct Bridge;
-template <typename T>
-T make_reflected_object(qjs::Object object);
-
-template <typename T>
-qjs::Object to_reflected_object(JSContext* ctx, const T& value);
-}  // namespace detail
-
-template <auto E>
-    requires std::is_enum_v<std::decay_t<decltype(E)>>
-struct Tag {
-    bool operator== (const Tag& other) const = default;
-};
-
-template <auto... ES>
-concept EnumValues =
-    (std::is_enum_v<std::decay_t<decltype(ES)>> && ...) &&
-    (std::same_as<std::decay_t<decltype(ES)>, std::decay_t<decltype((ES, ...))>> && ...);
-
-template <auto... Es>
-    requires EnumValues<Es...>
-struct TaggedUnion;
-
-#define TAG                                                                                        \
-    template <>                                                                                    \
-    struct Tag
-
-template <auto... Es>
-    requires EnumValues<Es...>
-struct TaggedUnion : public std::variant<Tag<Es>...> {
-    using TagType = std::common_type_t<std::decay_t<decltype(Es)>...>;
-    using std::variant<Tag<Es>...>::variant;
-    TaggedUnion() = default;
-    TaggedUnion(const TaggedUnion&) = default;
-    TaggedUnion(TaggedUnion&&) = default;
-    TaggedUnion& operator= (const TaggedUnion&) = default;
-    TaggedUnion& operator= (TaggedUnion&&) = default;
-
-    static TaggedUnion make(qjs::Object object) {
-        return detail::Bridge<TaggedUnion>::from_js(qjs::Value::from(object));
-    }
-
-    qjs::Object to_object(JSContext* ctx) const {
-        return detail::Bridge<TaggedUnion>::to_js(ctx, *this);
-    }
-
-    std::variant<Tag<Es>...>& variant() {
-        return static_cast<std::variant<Tag<Es>...>&>(*this);
-    }
-
-    const std::variant<Tag<Es>...>& variant() const {
-        return static_cast<const std::variant<Tag<Es>...>&>(*this);
-    }
-
-    template <typename V>
-    decltype(auto) visit(V&& visitor) const {
-        return std::visit(std::forward<V>(visitor), this->variant());
-    }
-
-    template <typename V>
-    decltype(auto) visit(V&& visitor) {
-        return std::visit(std::forward<V>(visitor), this->variant());
-    }
-
-    TagType type() const {
-        return visit([]<auto E>(const Tag<E>&) -> TagType { return E; });
-    }
-
-    template <auto E>
-    decltype(auto) get_if() {
-        return std::get_if<Tag<E>>(&this->variant());
-    }
-
-    template <auto E>
-    decltype(auto) get_if() const {
-        return std::get_if<Tag<E>>(&this->variant());
-    }
-
-    template <auto E>
-    decltype(auto) get() {
-        return std::get<Tag<E>>(this->variant());
-    }
-
-    template <auto E>
-    decltype(auto) get() const {
-        return std::get<Tag<E>>(this->variant());
-    }
-
-    bool operator== (const TaggedUnion& other) const {
-        return this->visit([&]<typename T>(const T& tag) -> bool {
-            return other.visit([&]<typename U>(const U& other_tag) -> bool {
-                if constexpr(std::is_same_v<T, U>) {
-                    return tag == other_tag;
-                } else {
-                    return false;
-                }
-            });
-        });
-    }
-};
-
-namespace detail {
-namespace et = kota;
-
-template <typename E>
-constexpr E enum_value(std::string_view name) {
-    if(auto val = et::meta::enum_value<E>(name); val.has_value()) {
-        return *val;
-    }
-    throw cpptrace::runtime_error(std::format("Invalid enum value name: {}", name));
-}
-
-template <typename E>
-constexpr std::string_view enum_name(E value) {
-    return et::meta::enum_name(value, "unknown");
-}
-
-template <typename E>
-std::vector<E> enum_values(const std::vector<std::string>& names) {
-    std::vector<E> values;
-    values.reserve(names.size());
-    for(const auto& name: names) {
-        values.push_back(enum_value<E>(name));
-    }
-    return values;
-}
-
-template <typename E>
-std::vector<std::string> enum_names(const std::vector<E>& values) {
-    std::vector<std::string> names;
-    names.reserve(values.size());
-    for(const auto& value: values) {
-        names.push_back(std::string(enum_name(value)));
-    }
-    return names;
-}
-
-template <typename T>
-struct property_name_mapper {
-    constexpr static std::string_view map(std::string_view field_name) {
-        return field_name;
-    }
-};
-
-template <typename T>
-struct Bridge {
-    static T from_js(const qjs::Value& value) {
-        return value.as<T>();
-    }
-
-    static auto to_js(JSContext* ctx, const T& value) {
-        return qjs::Value::from(ctx, value);
-    }
-};
-
-template <typename T>
-    requires et::meta::reflectable_class<T>
-struct Bridge<T> {
-    static T from_js(const qjs::Value& value) {
-        return make_reflected_object<T>(value.as<qjs::Object>());
-    }
-
-    static auto to_js(JSContext* ctx, const T& value) {
-        return to_reflected_object(ctx, value);
-    }
-};
-
-template <typename T>
-    requires std::is_enum_v<T>
-struct Bridge<T> {
-    static T from_js(const qjs::Value& value) {
-        return enum_value<T>(value.as<std::string>());
-    }
-
-    static auto to_js(JSContext* ctx, const T& value) {
-        return qjs::Value::from(ctx, std::string(enum_name(value)));
-    }
-};
-
-template <typename T>
-    requires std::is_enum_v<T>
-struct Bridge<std::vector<T>> {
-    static std::vector<T> from_js(const qjs::Value& value) {
-        auto names = value.as<qjs::Array<std::string>>().as<std::vector<std::string>>();
-        return enum_values<T>(names);
-    }
-
-    static auto to_js(JSContext* ctx, const std::vector<T>& vec) {
-        return qjs::Array<std::string>::from(ctx, enum_names(vec));
-    }
-};
-
-template <typename T>
-struct Bridge<std::vector<T>> {
-    static std::vector<T> from_js(const qjs::Value& value) {
-        return value.as<qjs::Array<T>>().template as<std::vector<T>>();
-    }
-
-    static auto to_js(JSContext* ctx, const std::vector<T>& vec) {
-        return qjs::Array<T>::from(ctx, vec);
-    }
-};
-
-template <auto... Es>
-    requires EnumValues<Es...>
-struct Bridge<TaggedUnion<Es...>> {
-    using Union = TaggedUnion<Es...>;
-
-    static Union from_js(const qjs::Value& value) {
-        auto object = value.as<qjs::Object>();
-
-        auto tag = object["type"].as<std::string>();
-
-        return dispatch<typename Union::TagType>(tag, [&]<auto E>(in_place_enum<E>) -> Union {
-            return make_reflected_object<Tag<E>>(object);
-        });
-    }
-
-    static auto to_js(JSContext* ctx, const Union& union_value) {
-        return union_value.visit([&]<auto E>(const Tag<E>& tag) {
-            auto object = to_reflected_object(ctx, tag);
-            object.set_property("type", std::string(enum_name(E)));
-            return object;
-        });
-    }
-};
-
-template <typename T>
-T read_property(const qjs::Object& object, std::string_view property_name) {
-    if constexpr(et::is_optional_v<T>) {
-        using value_type = typename T::value_type;
-        auto prop_val = object[std::string(property_name)];
-        if(!prop_val.is_undefined()) {
-            return Bridge<value_type>::from_js(prop_val);
-        } else {
-            return std::nullopt;
-        }
-    } else {
-        return Bridge<T>::from_js(object[std::string(property_name)]);
-    }
-}
-
-template <typename T>
-void write_property(qjs::Object& object,
-                    std::string_view property_name,
-                    JSContext* ctx,
-                    const T& value) {
-    if constexpr(et::is_optional_v<T>) {
-        using value_type = typename T::value_type;
-        if(value.has_value()) {
-            object.set_property(std::string(property_name), Bridge<value_type>::to_js(ctx, *value));
-        }
-    } else {
-        object.set_property(std::string(property_name), Bridge<T>::to_js(ctx, value));
-    }
-}
-
-template <typename T>
-T make_reflected_object(qjs::Object object) {
-    T value{};
-    et::meta::for_each(value, [&]<typename FieldType>(FieldType field) {
-        using field_type = std::remove_const_t<typename FieldType::type>;
-        field.value() =
-            read_property<field_type>(object, property_name_mapper<T>::map(FieldType::name()));
-    });
-    return value;
-}
-
-template <typename T>
-qjs::Object to_reflected_object(JSContext* ctx, const T& value) {
-    auto object = qjs::Object::empty_one(ctx);
-    et::meta::for_each(value, [&]<typename FieldType>(FieldType field) {
-        write_property(object, property_name_mapper<T>::map(FieldType::name()), ctx, field.value());
-    });
-    return object;
-}
-
-}  // namespace detail
 
 enum class ActionType { skip, drop, abort, modify };
 
@@ -306,11 +9,11 @@ struct CatterOptions {
     enum class StdioMode { inherit, capture };
 
     static CatterOptions make(qjs::Object object) {
-        return detail::make_reflected_object<CatterOptions>(std::move(object));
+        return make_reflected_object<CatterOptions>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const CatterOptions&) const = default;
@@ -324,11 +27,11 @@ struct CatterRuntime {
     enum class Type { inject, eslogger, env };
 
     static CatterRuntime make(qjs::Object object) {
-        return detail::make_reflected_object<CatterRuntime>(std::move(object));
+        return make_reflected_object<CatterRuntime>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const CatterRuntime&) const = default;
@@ -341,11 +44,11 @@ public:
 
 struct CatterConfig {
     static CatterConfig make(qjs::Object object) {
-        return detail::make_reflected_object<CatterConfig>(std::move(object));
+        return make_reflected_object<CatterConfig>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const CatterConfig&) const = default;
@@ -362,11 +65,11 @@ public:
 
 struct CommandData {
     static CommandData make(qjs::Object object) {
-        return detail::make_reflected_object<CommandData>(std::move(object));
+        return make_reflected_object<CommandData>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const CommandData&) const = default;
@@ -381,12 +84,24 @@ public:
 };
 
 struct ProcessResult {
+    struct name_mapper {
+        constexpr static std::string_view map(std::string_view field_name) {
+            if(field_name == "stdOut") {
+                return "stdout";
+            }
+            if(field_name == "stdErr") {
+                return "stderr";
+            }
+            return field_name;
+        }
+    };
+
     static ProcessResult make(qjs::Object object) {
-        return detail::make_reflected_object<ProcessResult>(std::move(object));
+        return make_reflected_object<ProcessResult>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const ProcessResult&) const = default;
@@ -399,11 +114,11 @@ public:
 
 struct CatterErr {
     static CatterErr make(qjs::Object object) {
-        return detail::make_reflected_object<CatterErr>(std::move(object));
+        return make_reflected_object<CatterErr>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const CatterErr&) const = default;
@@ -415,11 +130,11 @@ public:
 
 struct OptionItem {
     static OptionItem make(qjs::Object object) {
-        return detail::make_reflected_object<OptionItem>(std::move(object));
+        return make_reflected_object<OptionItem>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const OptionItem&) const = default;
@@ -434,11 +149,11 @@ public:
 
 struct OptionInfo {
     static OptionInfo make(qjs::Object object) {
-        return detail::make_reflected_object<OptionInfo>(std::move(object));
+        return make_reflected_object<OptionInfo>(std::move(object));
     }
 
     qjs::Object to_object(JSContext* ctx) const {
-        return detail::to_reflected_object(ctx, *this);
+        return to_reflected_object(ctx, *this);
     }
 
     bool operator== (const OptionInfo&) const = default;
@@ -465,18 +180,4 @@ TAG<ActionType::modify> {
     bool operator== (const Tag& other) const = default;
 };
 
-template <>
-struct detail::property_name_mapper<ProcessResult> {
-    constexpr static std::string_view map(std::string_view field_name) {
-        if(field_name == "stdOut") {
-            return "stdout";
-        }
-        if(field_name == "stdErr") {
-            return "stderr";
-        }
-        return field_name;
-    }
-};
-
-#undef TAG
 }  // namespace catter::js

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -188,16 +188,15 @@ std::string Atom::to_string() const noexcept {
     return result;
 }
 
-Value Object::get_property(const std::string& prop_name) const {
-    auto ret = Value{this->context(),
-                     JS_GetPropertyStr(this->context(), this->value(), prop_name.c_str())};
+Value Object::get_property(const char* prop_name) const {
+    auto ret = Value{this->context(), JS_GetPropertyStr(this->context(), this->value(), prop_name)};
     if(JS_HasException(this->context())) {
         throw qjs::JSException::dump(this->context());
     }
     return ret;
 }
 
-std::optional<Value> Object::get_optional_property(const std::string& prop_name) const noexcept {
+std::optional<Value> Object::get_optional_property(const char* prop_name) const noexcept {
     try {
         if(auto ret = get_property(prop_name); ret.is_undefined()) {
             return std::nullopt;

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -226,15 +226,18 @@ public:
     Object& operator= (Object&& other) = default;
     ~Object() = default;
 
-    Value get_property(const std::string& prop_name) const;
+    Value get_property(const char* prop_name) const;
+
+    Value get_property(const std::string& prop_name) const {
+        return get_property(prop_name.c_str());
+    }
 
     /**
      * @brief Get the property object, noticed that property maybe undefined.
      */
     template <typename T>
-        requires std::is_convertible_v<T, std::string>
-    Value operator[] (const T& prop_name) const {
-        return get_property(prop_name);
+    Value operator[] (T&& prop_name) const {
+        return get_property(std::forward<T>(prop_name));
     }
 
     /**
@@ -244,7 +247,11 @@ public:
      * @param prop_name
      * @return std::optional<Value>
      */
-    std::optional<Value> get_optional_property(const std::string& prop_name) const noexcept;
+    std::optional<Value> get_optional_property(const char* prop_name) const noexcept;
+
+    std::optional<Value> get_optional_property(const std::string& prop_name) const noexcept {
+        return get_optional_property(prop_name.c_str());
+    }
 
     /**
      * @brief Set a property on the JavaScript object, it is noexcept due to using in `C`.
@@ -256,10 +263,10 @@ public:
      * exception in `C` if needed.
      */
     template <typename T>
-    void set_property(const std::string& prop_name, T&& val) {
+    void set_property(const char* prop_name, T&& val) {
         if constexpr(std::is_same_v<JSValue, std::remove_cvref_t<T>>) {
             JSValue js_val = JS_DupValue(this->context(), val);
-            int ret = JS_SetPropertyStr(this->context(), this->value(), prop_name.c_str(), js_val);
+            int ret = JS_SetPropertyStr(this->context(), this->value(), prop_name, js_val);
             if(ret < 0) {
                 throw qjs::JSException::dump(this->context());
             }
@@ -267,20 +274,23 @@ public:
                                 { val.value() } -> std::convertible_to<JSValue>;
                             }) {
             JSValue js_val = JS_DupValue(this->context(), val.value());
-            int ret = JS_SetPropertyStr(this->context(), this->value(), prop_name.c_str(), js_val);
+            int ret = JS_SetPropertyStr(this->context(), this->value(), prop_name, js_val);
             if(ret < 0) {
                 throw qjs::JSException::dump(this->context());
             }
         } else {
             auto js_val = Value::from<std::remove_cv_t<T>>(this->context(), std::forward<T>(val));
-            int ret = JS_SetPropertyStr(this->context(),
-                                        this->value(),
-                                        prop_name.c_str(),
-                                        js_val.release());
+            int ret =
+                JS_SetPropertyStr(this->context(), this->value(), prop_name, js_val.release());
             if(ret < 0) {
                 throw qjs::JSException::dump(this->context());
             }
         }
+    }
+
+    template <typename T>
+    void set_property(const std::string& prop_name, T&& val) {
+        set_property(prop_name.c_str(), std::forward<T>(val));
     }
 
     template <typename T>

--- a/tests/unit/catter/core/js/http.cc
+++ b/tests/unit/catter/core/js/http.cc
@@ -133,6 +133,7 @@ private:
             "HTTP/1.1 {} {}\r\n"
             "Content-Type: {}\r\n"
             "X-Catter-Test: yes\r\n"
+            "x-catter-test: again\r\n"
             "Connection: close\r\n"
             "Content-Length: {}\r\n"
             "\r\n"
@@ -267,7 +268,8 @@ TEST_CASE(run_http_client_js_file_through_async_loop) {
             debug.assertThrow(res.ok);
             debug.assertThrow(res.status === 200);
             debug.assertThrow(res.header("content-type") === "application/json");
-            debug.assertThrow(res.header("x-catter-test") === "yes");
+            debug.assertThrow(res.header("x-catter-test") === "yes, again");
+            debug.assertThrow(!("rawHeaders" in res));
             debug.assertThrow(res.json().ok === true);
             debug.assertThrow(res.json().path === "/payload");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP responses now expose normalized headers as a convenient name/value object.
  * Duplicate response headers are combined into a single comma-separated value.
  * Added support for converting enums, collections, reflected objects, optional fields, and tagged unions between C++ and JavaScript.

* **Bug Fixes**
  * Header names are consistently normalized to lowercase.
  * Removed the legacy raw header representation from HTTP responses.
  * Improved JavaScript property access compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->