### PR TITLE
feat: implement EsmModuleLoader for ESM support

### DIFF
--- a/src/catter/core/js/esm_loader.cc
+++ b/src/catter/core/js/esm_loader.cc
@@ -78,10 +78,4 @@ std::string EsmModuleLoader::loader(const char* module_name) {
     std::string source{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
     return source;
 }
-
-std::unique_ptr<qjs::Runtime::ModuleLoader>
-    make_esm_module_loader(std::filesystem::path working_directory) {
-    return std::make_unique<EsmModuleLoader>(std::move(working_directory));
-}
-
 }  // namespace catter::js

--- a/src/catter/core/js/esm_loader.cc
+++ b/src/catter/core/js/esm_loader.cc
@@ -1,0 +1,87 @@
+#include "esm_loader.h"
+
+#include <format>
+#include <fstream>
+#include <iterator>
+
+namespace catter::js {
+
+namespace {
+
+bool is_path_specifier(std::string_view specifier) {
+    return specifier.starts_with("./") || specifier.starts_with("../") || specifier == "." ||
+           specifier == ".." || std::filesystem::path(specifier).is_absolute();
+}
+
+std::filesystem::path absolute_normalized(std::filesystem::path path,
+                                          const std::filesystem::path& working_directory) {
+    if(path.is_relative()) {
+        path = working_directory / std::move(path);
+    }
+    return std::filesystem::absolute(path).lexically_normal();
+}
+
+}  // namespace
+
+EsmModuleLoader::EsmModuleLoader(std::filesystem::path working_directory) :
+    working_directory(std::filesystem::absolute(std::move(working_directory)).lexically_normal()) {}
+
+std::filesystem::path EsmModuleLoader::resolve_path(const char* referrer_name,
+                                                    const char* module_name) const {
+    const std::string_view specifier{module_name ? module_name : ""};
+
+    if(specifier.starts_with("catter")) {
+        return specifier;
+    }
+
+    if(!is_path_specifier(specifier)) {
+        throw qjs::Exception("Unsupported ESM module specifier '{}'; only file paths are supported",
+                             specifier);
+    }
+
+    std::filesystem::path base = this->working_directory;
+    if(referrer_name && *referrer_name) {
+        auto referrer = std::filesystem::path(referrer_name);
+        if(referrer.is_relative()) {
+            referrer = this->working_directory / std::move(referrer);
+        }
+        base = referrer.parent_path();
+    }
+
+    auto resolved = absolute_normalized(std::filesystem::path(specifier), base);
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(resolved, ec);
+    if(ec || !exists) {
+        throw qjs::Exception("Cannot find module '{}' imported from '{}'",
+                             specifier,
+                             referrer_name ? referrer_name : "<entry>");
+    }
+    if(std::filesystem::is_directory(resolved, ec)) {
+        throw qjs::Exception("Directory import '{}' is not supported", resolved.string());
+    }
+    if(ec || !std::filesystem::is_regular_file(resolved, ec) || ec) {
+        throw qjs::Exception("Cannot load module '{}'", resolved.string());
+    }
+    return resolved;
+}
+
+std::string EsmModuleLoader::normalizer(const char* referrer_name, const char* module_name) {
+    return resolve_path(referrer_name, module_name).string();
+}
+
+std::string EsmModuleLoader::loader(const char* module_name) {
+    const auto path = resolve_path(nullptr, module_name);
+    std::ifstream input(path, std::ios::binary);
+    if(!input) {
+        throw qjs::Exception("Failed to read module '{}'", path.string());
+    }
+    std::string source{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+    return source;
+}
+
+std::unique_ptr<qjs::Runtime::ModuleLoader>
+    make_esm_module_loader(std::filesystem::path working_directory) {
+    return std::make_unique<EsmModuleLoader>(std::move(working_directory));
+}
+
+}  // namespace catter::js

--- a/src/catter/core/js/esm_loader.h
+++ b/src/catter/core/js/esm_loader.h
@@ -28,8 +28,4 @@ private:
 
     std::filesystem::path working_directory;
 };
-
-std::unique_ptr<qjs::Runtime::ModuleLoader>
-    make_esm_module_loader(std::filesystem::path working_directory);
-
 }  // namespace catter::js

--- a/src/catter/core/js/esm_loader.h
+++ b/src/catter/core/js/esm_loader.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "qjs.h"
+
+namespace catter::js {
+
+/**
+ * Path-only ESM loader.
+ *
+ * Specifiers are resolved relative to the importing file. Explicit absolute paths are also
+ * accepted. Extensions are never inferred and directory imports are rejected, matching Node's
+ * ESM path rules. All loaded files are treated as ES modules by the caller.
+ */
+class EsmModuleLoader final : public qjs::Runtime::ModuleLoader {
+public:
+    explicit EsmModuleLoader(std::filesystem::path working_directory);
+
+    std::string normalizer(const char* referrer_name, const char* module_name) override;
+    std::string loader(const char* module_name) override;
+
+private:
+    std::filesystem::path resolve_path(const char* referrer_name, const char* module_name) const;
+
+    std::filesystem::path working_directory;
+};
+
+std::unique_ptr<qjs::Runtime::ModuleLoader>
+    make_esm_module_loader(std::filesystem::path working_directory);
+
+}  // namespace catter::js

--- a/src/catter/core/js/js.cc
+++ b/src/catter/core/js/js.cc
@@ -11,6 +11,7 @@
 
 #include "apitool.h"
 #include "async.h"
+#include "esm_loader.h"
 
 extern "C" {
     extern const char _binary_lib_js_start[];
@@ -45,6 +46,7 @@ struct RuntimeState {
         on_execution = {};
         runtime = qjs::Runtime::create();
         config = std::move(next_config);
+        runtime.set_module_loader(make_esm_module_loader(config.pwd));
     }
 };
 

--- a/src/catter/core/js/js.cc
+++ b/src/catter/core/js/js.cc
@@ -67,11 +67,8 @@ std::string_view js_lib_source() {
 }
 
 kota::task<> eval_module(std::string_view input, const char* filename) {
-    constexpr int flags = JS_EVAL_FLAG_STRICT;
-
     auto& ctx = state.runtime.context();
-    auto result =
-        co_await state.js_loop.promise_to_task<void>(ctx.eval_module(input, filename, flags));
+    auto result = co_await state.js_loop.promise_to_task<void>(ctx.eval_module(input, filename));
     if(!result) {
         throw result.error().to_exception();
     }

--- a/src/catter/core/js/js.cc
+++ b/src/catter/core/js/js.cc
@@ -52,13 +52,6 @@ struct RuntimeState {
 
 RuntimeState state{};
 
-void register_catter_module(const qjs::Context& ctx) {
-    auto& mod = ctx.cmodule("catter-c");
-    for(auto& reg: catter::apitool::api_registers()) {
-        reg(mod, ctx);
-    }
-}
-
 std::string_view js_lib_source() {
     const std::string_view js_lib{_binary_lib_js_start, _binary_lib_js_end};
     auto last = js_lib.find_last_not_of('\0');
@@ -112,8 +105,10 @@ kota::task<> RuntimeScope::start(RuntimeConfig config) {
     std::exception_ptr error;
     try {
         const auto& ctx = state.runtime.context();
-        register_catter_module(ctx);
-
+        auto& mod = ctx.cmodule("catter-c");
+        for(auto& reg: catter::apitool::api_registers()) {
+            reg(mod, ctx);
+        }
         co_await eval_module(js_lib_source(), "catter");
     } catch(...) {
         error = std::current_exception();

--- a/src/catter/core/js/js.cc
+++ b/src/catter/core/js/js.cc
@@ -45,8 +45,8 @@ struct RuntimeState {
         on_command = {};
         on_execution = {};
         runtime = qjs::Runtime::create();
+        runtime.set_module_loader(std::make_unique<EsmModuleLoader>(next_config.pwd));
         config = std::move(next_config);
-        runtime.set_module_loader(make_esm_module_loader(config.pwd));
     }
 };
 

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -506,18 +506,6 @@ Value Context::eval(std::string_view input, const char* filename, int eval_flags
     return this->eval(input.data(), input.size(), filename, eval_flags);
 }
 
-Promise Context::eval_module(const char* input,
-                             size_t input_len,
-                             const char* filename,
-                             int eval_flags) const {
-    return this->eval(input, input_len, filename, eval_flags | JS_EVAL_TYPE_MODULE).as<Promise>();
-}
-
-Promise Context::eval_module(std::string_view input, const char* filename, int eval_flags) const {
-    return this->eval(input.data(), input.size(), filename, eval_flags | JS_EVAL_TYPE_MODULE)
-        .as<Promise>();
-}
-
 Object Context::global_this() const noexcept {
     return Object{this->js_context(), JS_GetGlobalObject(this->js_context())};
 }

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1519,10 +1519,12 @@ public:
     /** Callbacks used to resolve and load JavaScript source modules. */
     struct ModuleLoader {
         /** Resolve module_name relative to referrer_name and return its canonical module name. */
-        kota::function<std::string(const char* referrer_name, const char* module_name)> normalizer;
+        virtual std::string normalizer(const char* referrer_name, const char* module_name) = 0;
 
         /** Return the JavaScript source bytes for a canonical module name. */
-        kota::function<std::vector<char>(const char* module_name)> loader;
+        virtual std::vector<char> loader(const char* module_name) = 0;
+
+        virtual ~ModuleLoader() = default;
     };
 
     static Runtime create();
@@ -1537,7 +1539,7 @@ public:
      * Install or replace this runtime's JavaScript module loader.
      * The callbacks are retained by the runtime and used by subsequent module evaluations.
      */
-    void set_module_loader(ModuleLoader loader) const noexcept {
+    void set_module_loader(std::unique_ptr<ModuleLoader> loader) const noexcept {
         this->raw->module_loader = std::move(loader);
 
         return JS_SetModuleLoaderFunc(
@@ -1545,7 +1547,7 @@ public:
             [](JSContext* ctx, const char* module_base_name, const char* module_name, void* opaque)
                 -> char* {
                 auto raw = static_cast<Raw*>(opaque);
-                assert(raw && raw->module_loader.has_value() && "Module loader is not set");
+                assert(raw && raw->module_loader && "Module loader is not set");
 
                 auto normalized_name =
                     raw->module_loader->normalizer(module_base_name, module_name);
@@ -1554,7 +1556,7 @@ public:
             },
             [](JSContext* ctx, const char* module_name, void* opaque) -> JSModuleDef* {
                 auto raw = static_cast<Raw*>(opaque);
-                assert(raw && raw->module_loader.has_value() && "Module loader is not set");
+                assert(raw && raw->module_loader && "Module loader is not set");
 
                 auto source = raw->module_loader->loader(module_name);
 
@@ -1618,7 +1620,7 @@ private:
             void operator() (JSRuntime* rt) const noexcept;
         };
 
-        std::optional<ModuleLoader> module_loader = std::nullopt;
+        std::unique_ptr<ModuleLoader> module_loader = nullptr;
         std::unique_ptr<JSRuntime, JSRuntimeDeleter> rt = nullptr;
         std::unordered_map<std::string, Context> ctxs{};
     };

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1058,12 +1058,13 @@ template <class Num>
     requires std::is_integral_v<Num>
 struct value_trans<Num> {
     static Value from(JSContext* ctx, Num value) noexcept {
-        if constexpr(std::is_unsigned_v<Num> && sizeof(Num) <= sizeof(uint32_t)) {
-            return Value{ctx, JS_NewUint32(ctx, static_cast<uint32_t>(value))};
-        } else if constexpr(std::is_signed_v<Num>) {
-            return Value{ctx, JS_NewInt64(ctx, static_cast<int64_t>(value))};
+        static_assert(sizeof(Num) <= sizeof(uint64_t),
+                      "Integral type is too large to be represented in JavaScript");
+
+        if constexpr(std::is_unsigned_v<Num>) {
+            return Value{ctx, JS_NewUint64(ctx, static_cast<uint64_t>(value))};
         } else {
-            static_assert(kota::dependent_false<Num>, "Unsupported integral type for value");
+            return Value{ctx, JS_NewInt64(ctx, static_cast<int64_t>(value))};
         }
     }
 
@@ -1416,15 +1417,50 @@ public:
     Value eval(std::string_view input, const char* filename, int eval_flags) const;
 
     /**
-     * Evaluate a JavaScript module, it will automatically add flag JS_EVAL_TYPE_MODULE to
-     * eval_flags.
+     * Evaluate a strict-mode classic script synchronously in this context's global scope.
+     * The returned value is the script's completion value.
      */
-    Promise eval_module(const char* input,
-                        size_t input_len,
-                        const char* filename,
-                        int eval_flags) const;
+    Value eval_script(const char* input, size_t input_len, const char* filename) const {
+        return this->eval(input, input_len, filename, JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_STRICT);
+    }
 
-    Promise eval_module(std::string_view input, const char* filename, int eval_flags) const;
+    /** String-view overload of eval_script(). */
+    Value eval_script(std::string_view input, const char* filename) const {
+        return this->eval_script(input.data(), input.size(), filename);
+    }
+
+    /**
+     * Evaluate a strict-mode classic script with top-level await support.
+     * The returned promise settles when the script and all of its top-level awaits complete.
+     */
+    Promise async_eval_script(const char* input, size_t input_len, const char* filename) const {
+        return this
+            ->eval(input,
+                   input_len,
+                   filename,
+                   JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC | JS_EVAL_FLAG_STRICT)
+            .as<Promise>();
+    }
+
+    /** String-view overload of async_eval_script(). */
+    Promise async_eval_script(std::string_view input, const char* filename) const {
+        return this->async_eval_script(input.data(), input.size(), filename);
+    }
+
+    /**
+     * Evaluate a strict-mode ECMAScript module.
+     * Imports are resolved through the Runtime module loader, and the returned promise settles
+     * after module evaluation, including top-level awaits, has completed.
+     */
+    Promise eval_module(const char* input, size_t input_len, const char* filename) const {
+        return this->eval(input, input_len, filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_STRICT)
+            .as<Promise>();
+    }
+
+    /** String-view overload of eval_module(). */
+    Promise eval_module(std::string_view input, const char* filename) const {
+        return this->eval_module(input.data(), input.size(), filename);
+    }
 
     Object global_this() const noexcept;
 
@@ -1480,6 +1516,15 @@ public:
     Runtime& operator= (Runtime&&) = default;
     ~Runtime() = default;
 
+    /** Callbacks used to resolve and load JavaScript source modules. */
+    struct ModuleLoader {
+        /** Resolve module_name relative to referrer_name and return its canonical module name. */
+        kota::function<std::string(const char* referrer_name, const char* module_name)> normalizer;
+
+        /** Return the JavaScript source bytes for a canonical module name. */
+        kota::function<std::vector<char>(const char* module_name)> loader;
+    };
+
     static Runtime create();
 
     // Get or create a context with the given name
@@ -1487,6 +1532,46 @@ public:
     const Context& context(const std::string& name = "default") const;
 
     JSRuntime* js_runtime() const noexcept;
+
+    /**
+     * Install or replace this runtime's JavaScript module loader.
+     * The callbacks are retained by the runtime and used by subsequent module evaluations.
+     */
+    void set_module_loader(ModuleLoader loader) const noexcept {
+        this->raw->module_loader = std::move(loader);
+
+        return JS_SetModuleLoaderFunc(
+            this->js_runtime(),
+            [](JSContext* ctx, const char* module_base_name, const char* module_name, void* opaque)
+                -> char* {
+                auto raw = static_cast<Raw*>(opaque);
+                assert(raw && raw->module_loader.has_value() && "Module loader is not set");
+
+                auto normalized_name =
+                    raw->module_loader->normalizer(module_base_name, module_name);
+
+                return js_strdup(ctx, normalized_name.c_str());
+            },
+            [](JSContext* ctx, const char* module_name, void* opaque) -> JSModuleDef* {
+                auto raw = static_cast<Raw*>(opaque);
+                assert(raw && raw->module_loader.has_value() && "Module loader is not set");
+
+                auto source = raw->module_loader->loader(module_name);
+
+                JSValue module_value = JS_Eval(ctx,
+                                               source.data(),
+                                               source.size(),
+                                               module_name,
+                                               JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+
+                if(JS_IsException(module_value))
+                    return NULL;
+
+                JSModuleDef* module = (JSModuleDef*)JS_VALUE_GET_PTR(module_value);
+                return module;
+            },
+            this->raw.get());
+    }
 
     bool has_job_pending() const noexcept {
         return JS_IsJobPending(this->js_runtime());
@@ -1533,6 +1618,7 @@ private:
             void operator() (JSRuntime* rt) const noexcept;
         };
 
+        std::optional<ModuleLoader> module_loader = std::nullopt;
         std::unique_ptr<JSRuntime, JSRuntimeDeleter> rt = nullptr;
         std::unordered_map<std::string, Context> ctxs{};
     };

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1567,17 +1567,18 @@ public:
 
                 try {
                     auto source = raw->module_loader->loader(module_name);
-                    JSValue module_value = JS_Eval(ctx,
-                                                   source.data(),
-                                                   source.size(),
-                                                   module_name,
-                                                   JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+                    auto module_value =
+                        Value{ctx,
+                              JS_Eval(ctx,
+                                      source.data(),
+                                      source.size(),
+                                      module_name,
+                                      JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY)};
 
-                    if(JS_IsException(module_value))
+                    if(module_value.is_exception())
                         return NULL;
 
-                    JSModuleDef* module = (JSModuleDef*)JS_VALUE_GET_PTR(module_value);
-                    return module;
+                    return (JSModuleDef*)JS_VALUE_GET_PTR(module_value.value());
                 } catch(const std::exception& e) {
                     JS_ThrowInternalError(ctx, "Exception in module loader: %s", e.what());
                     return nullptr;

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1522,7 +1522,7 @@ public:
         virtual std::string normalizer(const char* referrer_name, const char* module_name) = 0;
 
         /** Return the JavaScript source bytes for a canonical module name. */
-        virtual std::vector<char> loader(const char* module_name) = 0;
+        virtual std::string loader(const char* module_name) = 0;
 
         virtual ~ModuleLoader() = default;
     };
@@ -1548,29 +1548,43 @@ public:
                 -> char* {
                 auto raw = static_cast<Raw*>(opaque);
                 assert(raw && raw->module_loader && "Module loader is not set");
+                try {
+                    auto normalized_name =
+                        raw->module_loader->normalizer(module_base_name, module_name);
 
-                auto normalized_name =
-                    raw->module_loader->normalizer(module_base_name, module_name);
-
-                return js_strdup(ctx, normalized_name.c_str());
+                    return js_strdup(ctx, normalized_name.c_str());
+                } catch(const std::exception& e) {
+                    JS_ThrowInternalError(ctx, "Exception in module normalizer: %s", e.what());
+                    return nullptr;
+                } catch(...) {
+                    JS_ThrowInternalError(ctx, "Unknown exception in module normalizer");
+                    return nullptr;
+                }
             },
             [](JSContext* ctx, const char* module_name, void* opaque) -> JSModuleDef* {
                 auto raw = static_cast<Raw*>(opaque);
                 assert(raw && raw->module_loader && "Module loader is not set");
 
-                auto source = raw->module_loader->loader(module_name);
+                try {
+                    auto source = raw->module_loader->loader(module_name);
+                    JSValue module_value = JS_Eval(ctx,
+                                                   source.data(),
+                                                   source.size(),
+                                                   module_name,
+                                                   JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
 
-                JSValue module_value = JS_Eval(ctx,
-                                               source.data(),
-                                               source.size(),
-                                               module_name,
-                                               JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+                    if(JS_IsException(module_value))
+                        return NULL;
 
-                if(JS_IsException(module_value))
-                    return NULL;
-
-                JSModuleDef* module = (JSModuleDef*)JS_VALUE_GET_PTR(module_value);
-                return module;
+                    JSModuleDef* module = (JSModuleDef*)JS_VALUE_GET_PTR(module_value);
+                    return module;
+                } catch(const std::exception& e) {
+                    JS_ThrowInternalError(ctx, "Exception in module loader: %s", e.what());
+                    return nullptr;
+                } catch(...) {
+                    JS_ThrowInternalError(ctx, "Unknown exception in module loader");
+                    return nullptr;
+                }
             },
             this->raw.get());
     }

--- a/src/catter/core/option.h
+++ b/src/catter/core/option.h
@@ -84,7 +84,7 @@ struct CatterConfig {
     DecoKV(names = {"-m", "--mode"},
            meta_var = "<Mode>",
            help = "mode of operation, e.g. 'inject'",
-           required = true)
+           required = false)
     <config::RunMode> mode = config::RunMode{};
 
     DecoKV(names = {"-d", "--dir"},

--- a/tests/unit/catter/core/esm_loader.cc
+++ b/tests/unit/catter/core/esm_loader.cc
@@ -198,11 +198,11 @@ TEST_CASE(api_source_style_project_dependency_graph_is_resolved_once) {
         const auto bootstrap_path = (fixture.root / "bootstrap.js").string();
 
         constexpr auto script_content =  "import './index.js';\n"
-                                                            "if (globalThis.projectResult !== 575) {\n"
-                                                            "  throw new Error('unexpected project result');\n" "}\n"
-                                                            "if (globalThis.sharedLoads !== 1) {\n"
-                                                            "  throw new Error('shared module was evaluated more than once');\n"
-                                                            "}\n";
+                                    "if (globalThis.projectResult !== 575) {\n"
+                                    "  throw new Error('unexpected project result');\n" "}\n"
+                                    "if (globalThis.sharedLoads !== 1) {\n"
+                                    "  throw new Error('shared module was evaluated more than once');\n"
+                                    "}\n";
 
         auto task = async_run({.script_content = script_content,
                                .script_path = bootstrap_path,

--- a/tests/unit/catter/core/esm_loader.cc
+++ b/tests/unit/catter/core/esm_loader.cc
@@ -1,0 +1,230 @@
+#include "js/esm_loader.h"
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string_view>
+#include <kota/zest/macro.h>
+#include <kota/zest/zest.h>
+#include <kota/async/io/loop.h>
+
+#include "js/js.h"
+#include "js/qjs.h"
+
+namespace fs = std::filesystem;
+using namespace catter;
+
+namespace {
+
+template <typename Fn>
+bool throws_with_message(Fn&& fn, std::string_view needle) {
+    try {
+        fn();
+    } catch(const catter::qjs::Exception& error) {
+        return std::string_view(error.what()).contains(needle);
+    } catch(...) {}
+    return false;
+}
+
+struct Fixture {
+    Fixture() {
+        static std::atomic_uint64_t serial{0};
+        root = fs::temp_directory_path() /
+               ("catter_esm_loader_" + std::to_string(serial.fetch_add(1)));
+        fs::create_directories(root / "nested");
+    }
+
+    ~Fixture() {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+
+    void write(const fs::path& path, std::string_view source) {
+        fs::create_directories(path.parent_path());
+        std::ofstream output(path, std::ios::binary);
+        output << source;
+    }
+
+    fs::path root;
+};
+
+}  // namespace
+
+TEST_SUITE(esm_loader_tests) {
+
+TEST_CASE(path_resolution_uses_parent_without_extension_inference) {
+    Fixture fixture;
+    fixture.write(fixture.root / "nested" / "dep.js", "export const value = 42;");
+    catter::js::EsmModuleLoader loader{fixture.root};
+
+    auto resolved =
+        loader.normalizer((fixture.root / "main.js").string().c_str(), "./nested/dep.js");
+    EXPECT_TRUE(fs::path(resolved) == fixture.root / "nested" / "dep.js");
+    EXPECT_TRUE(throws_with_message(
+        [&]() {
+            (void)loader.normalizer((fixture.root / "main.js").string().c_str(), "./nested/dep");
+        },
+        "Cannot find module"));
+}
+
+TEST_CASE(path_resolution_rejects_directories_and_non_path_specifiers) {
+    Fixture fixture;
+    catter::js::EsmModuleLoader loader{fixture.root};
+
+    EXPECT_TRUE(throws_with_message(
+        [&]() { (void)loader.normalizer((fixture.root / "main.js").string().c_str(), "./nested"); },
+        "Directory import"));
+    EXPECT_TRUE(throws_with_message(
+        [&]() { (void)loader.normalizer((fixture.root / "main.js").string().c_str(), "package"); },
+        "only file paths are supported"));
+}
+
+TEST_CASE(loader_reads_canonical_file_name) {
+    Fixture fixture;
+    fixture.write(fixture.root / "dep.js", "export const value = 42;");
+    catter::js::EsmModuleLoader loader{fixture.root};
+
+    auto source = loader.loader((fixture.root / "dep.js").string().c_str());
+    EXPECT_TRUE(source == "export const value = 42;");
+}
+
+struct ScriptRunConfig {
+    std::string script_content;
+    std::string script_path;
+    fs::path working_directory;
+};
+
+kota::task<> async_run(ScriptRunConfig config) {
+    catter::js::RuntimeScope runtime;
+
+    std::exception_ptr error;
+    try {
+        co_await runtime.start({.pwd = std::move(config.working_directory)});
+        co_await catter::js::run_script(config.script_content, config.script_path);
+    } catch(...) {
+        error = std::current_exception();
+    }
+
+    co_await runtime.stop();
+
+    if(error) {
+        std::rethrow_exception(error);
+    }
+    co_return;
+}
+
+TEST_CASE(api_source_style_project_dependency_graph_is_resolved_once) {
+    auto f = [&]() {
+        Fixture fixture;
+        fixture.write(fixture.root / "index.js",
+                      "import { cdbValue } from './cdb/index.js';\n"
+                      "import { optionValue } from './option/index.js';\n"
+                      "import { compilerValue } from './cmd/compiler/index.js';\n"
+                      "import { scriptValue } from './scripts/index.js';\n"
+                      "import { sharedValue } from './data/flat-tree.js';\n"
+                      "globalThis.projectResult = cdbValue + optionValue + compilerValue + "
+                      "scriptValue + sharedValue;\n");
+
+        // Mirrors api/src/data/index.ts and api/src/data/flat-tree.ts.
+        fixture.write(fixture.root / "data" / "index.js",
+                      "export { sharedValue } from './flat-tree.js';\n");
+        fixture.write(fixture.root / "data" / "flat-tree.js",
+                    "import { ioValue } from '../io.js';\n"
+                    "globalThis.sharedLoads = (globalThis.sharedLoads || 0) + 1;\n"
+                    "export const sharedValue = 40;\n");
+
+        // Mirrors the root-level utility imports used throughout api/src.
+        fixture.write(fixture.root / "index-helper.js", "export const rootHelper = 1;\n");
+        fixture.write(fixture.root / "io.js",
+                      "import './index-helper.js';\n" "export const ioValue = 41;\n");
+        fixture.write(
+            fixture.root / "fs.js",
+            "import { ioValue } from './io.js';\n" "export const fsValue = ioValue + 1;\n");
+
+        // Mirrors api/src/cdb/index.ts and cdb-manager.ts.
+        fixture.write(fixture.root / "cdb" / "cdb.js",
+                      "import { fsValue } from '../fs.js';\n" "export const cdbCore = fsValue;\n");
+        fixture.write(
+            fixture.root / "cdb" / "cdb-manager.js",
+            "import { ioValue } from '../io.js';\n" "export const cdbManager = ioValue;\n");
+        fixture.write(fixture.root / "cdb" / "index.js",
+                    "import { cdbCore } from './cdb.js';\n"
+                    "import { cdbManager } from './cdb-manager.js';\n"
+                    "export const cdbValue = cdbCore + cdbManager;\n");
+
+        // Mirrors api/src/option/index.ts importing both siblings and parent utilities.
+        fixture.write(fixture.root / "option" / "types.js", "export const optionType = 1;\n");
+        fixture.write(fixture.root / "option" / "index.js",
+                    "import { optionType } from './types.js';\n"
+                    "import { sharedValue } from '../data/flat-tree.js';\n"
+                    "import { ioValue } from '../io.js';\n"
+                    "export const optionValue = optionType + sharedValue + ioValue;\n");
+
+        // Mirrors api/src/scripts/index.ts and its cdb/cmd-tree/view dependencies.
+        fixture.write(
+            fixture.root / "view" / "tree-renderer.js",
+            "import { sharedValue } from '../data/index.js';\n" "export const viewValue = sharedValue;\n");
+        fixture.write(fixture.root / "view" / "index.js",
+                      "export { viewValue } from './tree-renderer.js';\n");
+        fixture.write(fixture.root / "scripts" / "cdb.js",
+                    "import { cdbValue } from '../cdb/index.js';\n"
+                    "import { sharedValue } from '../data/index.js';\n"
+                    "export const scriptCdb = cdbValue + sharedValue;\n");
+        fixture.write(fixture.root / "scripts" / "cmd-tree.js",
+                    "import { cdbValue } from '../cdb/index.js';\n"
+                    "import { viewValue } from '../view/index.js';\n"
+                    "export const scriptTree = cdbValue + viewValue;\n");
+        fixture.write(fixture.root / "scripts" / "index.js",
+                    "import { scriptCdb } from './cdb.js';\n"
+                    "import { scriptTree } from './cmd-tree.js';\n"
+                    "export const scriptValue = scriptCdb + scriptTree;\n");
+
+        // Mirrors the deep api/src/cmd/compiler/{analysis,parsers,resolver} graph.
+        fixture.write(
+            fixture.root / "cmd" / "compiler" / "parsers" / "index.js",
+            "import { optionValue } from '../../../option/index.js';\n" "export const parserValue = optionValue;\n");
+        fixture.write(
+            fixture.root / "cmd" / "compiler" / "resolver" / "index.js",
+            "import { fsValue } from '../../../fs.js';\n" "export const resolverValue = fsValue;\n");
+        fixture.write(fixture.root / "cmd" / "compiler" / "analysis.js",
+                    "import { parserValue } from './parsers/index.js';\n"
+                    "import { resolverValue } from './resolver/index.js';\n"
+                    "export const analysisValue = parserValue + resolverValue;\n");
+        fixture.write(
+            fixture.root / "cmd" / "compiler" / "index.js",
+            "import { analysisValue } from './analysis.js';\n" "export const compilerValue = analysisValue;\n");
+
+        const auto entry_path = (fixture.root / "index.js").string();
+        const auto bootstrap_path = (fixture.root / "bootstrap.js").string();
+
+        constexpr auto script_content =  "import './index.js';\n"
+                                                            "if (globalThis.projectResult !== 575) {\n"
+                                                            "  throw new Error('unexpected project result');\n" "}\n"
+                                                            "if (globalThis.sharedLoads !== 1) {\n"
+                                                            "  throw new Error('shared module was evaluated more than once');\n"
+                                                            "}\n";
+
+        auto task = async_run({.script_content = script_content,
+                               .script_path = bootstrap_path,
+                               .working_directory = fixture.root});
+        kota::event_loop loop;
+        loop.schedule(task);
+        loop.run();
+        task.result();
+
+        catter::js::EsmModuleLoader path_loader{fixture.root};
+        const auto from_data_index =
+            path_loader.normalizer((fixture.root / "data" / "index.js").string().c_str(),
+                                   "./flat-tree.js");
+        const auto from_option =
+            path_loader.normalizer((fixture.root / "option" / "index.js").string().c_str(),
+                                   "../data/flat-tree.js");
+        const auto from_root = path_loader.normalizer(entry_path.c_str(), "./data/flat-tree.js");
+        EXPECT_TRUE(from_data_index == from_option);
+        EXPECT_TRUE(from_option == from_root);
+    };
+
+    EXPECT_NOTHROWS(f());
+}
+
+};  // TEST_SUITE(esm_loader_tests)

--- a/tests/unit/catter/core/qjs.cc
+++ b/tests/unit/catter/core/qjs.cc
@@ -1,5 +1,6 @@
 #include "js/qjs.h"
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -210,23 +211,27 @@ TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
     EXPECT_TRUE(async_result.is_fulfilled());
     EXPECT_TRUE(global["asyncResult"].as<int64_t>() == 42);
 
-    std::string normalized_referrer;
-    std::string normalized_specifier;
-    std::string loaded_name;
-    runtime.set_module_loader({
-        .normalizer =
-            [&](const char* referrer_name, const char* module_name) {
-                normalized_referrer = referrer_name;
-                normalized_specifier = module_name;
-                return std::string{"virtual:dependency"};
-            },
-        .loader =
-            [&](const char* module_name) {
-                loaded_name = module_name;
-                constexpr std::string_view source = "export const value = 6 * 7;";
-                return std::vector<char>{source.begin(), source.end()};
-            },
-    });
+    struct Loader : public qjs::Runtime::ModuleLoader {
+        std::string normalizer(const char* referrer_name, const char* module_name) override {
+            normalized_referrer = referrer_name;
+            normalized_specifier = module_name;
+            return "virtual:dependency";
+        }
+
+        std::vector<char> loader(const char* module_name) override {
+            loaded_name = module_name;
+            constexpr std::string_view source = "export const value = 6 * 7;";
+            return std::vector<char>{source.begin(), source.end()};
+        }
+
+        std::string normalized_referrer;
+        std::string normalized_specifier;
+        std::string loaded_name;
+    };
+
+    auto loader = std::make_unique<Loader>();
+    auto loader_ptr = loader.get();
+    runtime.set_module_loader(std::move(loader));
 
     auto module_result = ctx.eval_module(R"(
             import { value } from './dependency.js';
@@ -237,9 +242,9 @@ TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
 
     EXPECT_TRUE(module_result.is_fulfilled());
     EXPECT_TRUE(global["moduleResult"].as<int64_t>() == 42);
-    EXPECT_TRUE(normalized_referrer == "main-module.js");
-    EXPECT_TRUE(normalized_specifier == "./dependency.js");
-    EXPECT_TRUE(loaded_name == "virtual:dependency");
+    EXPECT_TRUE(loader_ptr->normalized_referrer == "main-module.js");
+    EXPECT_TRUE(loader_ptr->normalized_specifier == "./dependency.js");
+    EXPECT_TRUE(loader_ptr->loaded_name == "virtual:dependency");
 };
 
 TEST_CASE(object_property_apis_cover_reads_writes_and_exceptional_access) {

--- a/tests/unit/catter/core/qjs.cc
+++ b/tests/unit/catter/core/qjs.cc
@@ -156,11 +156,13 @@ TEST_CASE(value_conversions_cover_supported_types_copy_move_and_type_mismatch) {
         auto bool_value = qjs::Value::from(ctx.js_context(), true);
         auto signed_value = qjs::Value::from(ctx.js_context(), int64_t{-7});
         auto unsigned_value = qjs::Value::from(ctx.js_context(), uint32_t{11});
+        auto wide_unsigned_value = qjs::Value::from(ctx.js_context(), uint64_t{1} << 32);
         auto string_value = qjs::Value::from(ctx.js_context(), std::string{"hello"});
 
         EXPECT_TRUE(bool_value.to<bool>().value_or(false));
         EXPECT_TRUE(signed_value.as<int64_t>() == -7);
         EXPECT_TRUE(unsigned_value.as<uint32_t>() == 11);
+        EXPECT_TRUE(wide_unsigned_value.as<uint64_t>() == (uint64_t{1} << 32));
         EXPECT_TRUE(string_value.as<std::string>() == "hello");
 
         auto copied_string = string_value;
@@ -185,6 +187,59 @@ TEST_CASE(value_conversions_cover_supported_types_copy_move_and_type_mismatch) {
     EXPECT_FALSE(bool_value.to<std::string>().has_value());
     EXPECT_TRUE(throws_with_message([&]() { (void)bool_value.as<std::string>(); },
                                     "Value is not a string"));
+};
+
+TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
+    auto runtime = qjs::Runtime::create();
+    auto& ctx = runtime.context();
+    auto global = ctx.global_this();
+
+    constexpr std::string_view sync_source = "globalThis.syncResult = 40 + 2;";
+    auto sync_result = ctx.eval_script(sync_source.data(), sync_source.size(), "sync-script.js");
+    EXPECT_TRUE(sync_result.as<int64_t>() == 42);
+    EXPECT_TRUE(global["syncResult"].as<int64_t>() == 42);
+    EXPECT_TRUE(throws_with_message(
+        [&]() { (void)ctx.eval_script("undeclaredValue = 1", "strict-script.js"); },
+        "ReferenceError"));
+
+    auto async_result =
+        ctx.async_eval_script("await Promise.resolve(); globalThis.asyncResult = 21 * 2;",
+                              "async-script.js");
+    EXPECT_TRUE(async_result.is_pending());
+    drain_jobs(runtime);
+    EXPECT_TRUE(async_result.is_fulfilled());
+    EXPECT_TRUE(global["asyncResult"].as<int64_t>() == 42);
+
+    std::string normalized_referrer;
+    std::string normalized_specifier;
+    std::string loaded_name;
+    runtime.set_module_loader({
+        .normalizer =
+            [&](const char* referrer_name, const char* module_name) {
+                normalized_referrer = referrer_name;
+                normalized_specifier = module_name;
+                return std::string{"virtual:dependency"};
+            },
+        .loader =
+            [&](const char* module_name) {
+                loaded_name = module_name;
+                constexpr std::string_view source = "export const value = 6 * 7;";
+                return std::vector<char>{source.begin(), source.end()};
+            },
+    });
+
+    auto module_result = ctx.eval_module(R"(
+            import { value } from './dependency.js';
+            globalThis.moduleResult = value;
+        )",
+                                         "main-module.js");
+    drain_jobs(runtime);
+
+    EXPECT_TRUE(module_result.is_fulfilled());
+    EXPECT_TRUE(global["moduleResult"].as<int64_t>() == 42);
+    EXPECT_TRUE(normalized_referrer == "main-module.js");
+    EXPECT_TRUE(normalized_specifier == "./dependency.js");
+    EXPECT_TRUE(loaded_name == "virtual:dependency");
 };
 
 TEST_CASE(object_property_apis_cover_reads_writes_and_exceptional_access) {

--- a/tests/unit/catter/core/qjs.cc
+++ b/tests/unit/catter/core/qjs.cc
@@ -218,10 +218,9 @@ TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
             return "virtual:dependency";
         }
 
-        std::vector<char> loader(const char* module_name) override {
+        std::string loader(const char* module_name) override {
             loaded_name = module_name;
-            constexpr std::string_view source = "export const value = 6 * 7;";
-            return std::vector<char>{source.begin(), source.end()};
+            return "export const value = 6 * 7;";
         }
 
         std::string normalized_referrer;

--- a/xmake.lua
+++ b/xmake.lua
@@ -122,7 +122,7 @@ end
 --     end
 -- end
 
-add_requires("quickjs-ng", {version = "v0.11.0"})
+add_requires("quickjs-ng", {version = "v0.15.0"})
 add_requires("spdlog", {version = "1.15.3", configs = {header_only = false, std_format = true, noexcept = true}})
 add_requires("kotatsu")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a filesystem-based ES module loader that resolves only file-path-like specifiers (relative, absolute, `"."/".."`), normalizes paths, and rejects directory/non-file imports with clear errors.
  - Added runtime support for a customizable module loader (specifier normalization + module source loading).
  - Added strict evaluation helpers for scripts and ES modules, supporting both sync and async flows.
- **Improvements**
  - Made `--mode` optional.
  - Tightened integer conversion handling for larger unsigned/signed values.
- **Tests**
  - Added comprehensive unit tests for ESM loader resolution, dependency graph behavior, and module/script evaluation.
- **Chores**
  - Updated the `quickjs-ng` dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->