### PR TITLE
refactor: replace references with values for context in JS runtime

### DIFF
--- a/src/catter/core/js/js.cc
+++ b/src/catter/core/js/js.cc
@@ -62,7 +62,7 @@ std::string_view js_lib_source() {
 }
 
 kota::task<> eval_module(std::string_view input, const char* filename) {
-    auto& ctx = state.runtime.context();
+    auto ctx = state.runtime.context();
     auto result = co_await state.js_loop.promise_to_task<void>(ctx.eval_module(input, filename));
     if(!result) {
         throw result.error().to_exception();

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -1,6 +1,7 @@
 #include "qjs.h"
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <utility>
 #include <quickjs.h>
@@ -466,19 +467,19 @@ void Context::Raw::JSContextDeleter::operator() (JSContext* ctx) const noexcept 
 }
 
 const CModule& Context::cmodule(const std::string& name) const {
-    if(auto it = this->raw->modules.find(name); it != this->raw->modules.end()) {
+    auto raw = Raw::from(this->js_context());
+    assert(raw != nullptr && "Raw context should not be null when creating a C module");
+
+    if(auto it = raw->modules.find(name); it != raw->modules.end()) {
         return it->second;
     }
 
     auto m = JS_NewCModule(this->js_context(), name.data(), [](JSContext* js_ctx, JSModuleDef* m) {
-        auto* ctx = Context::get_opaque(js_ctx);
+        auto* raw = Raw::from(js_ctx);
+        assert(raw != nullptr && "Raw context should not be null when creating a C module");
+
         auto atom = Atom(js_ctx, JS_GetModuleName(js_ctx, m));
-
-        if(!ctx) {
-            return -1;
-        }
-
-        auto& mod = ctx->modules[atom.to_string()];
+        auto& mod = raw->modules[atom.to_string()];
         for(auto& kv: mod.exports_list()) {
             JS_SetModuleExport(js_ctx, m, kv.name.c_str(), kv.value.release());
         }
@@ -488,7 +489,7 @@ const CModule& Context::cmodule(const std::string& name) const {
         throw qjs::Exception("Failed to create new C module");
     }
 
-    return this->raw->modules.emplace(name, CModule(this->js_context(), m, name)).first->second;
+    return raw->modules.emplace(name, CModule(this->js_context(), m, name)).first->second;
 }
 
 Value
@@ -515,24 +516,14 @@ bool Context::has_exception() const noexcept {
 }
 
 JSContext* Context::js_context() const noexcept {
-    return this->raw->ctx.get();
+    return this->ctx;
 }
 
 Context::operator bool() const noexcept {
-    return this->raw != nullptr;
+    return this->ctx != nullptr;
 }
 
-void Context::set_opaque() noexcept {
-    JS_SetContextOpaque(this->js_context(), this->raw.get());
-}
-
-Context::Raw* Context::get_opaque(JSContext* ctx) noexcept {
-    return static_cast<Raw*>(JS_GetContextOpaque(ctx));
-}
-
-Context::Context(JSContext* js_ctx) noexcept : raw(std::make_unique<Raw>(js_ctx)) {
-    this->set_opaque();
-}
+Context::Context(JSContext* ctx) noexcept : ctx(ctx) {}
 
 Runtime::Raw::Raw(JSRuntime* rt) noexcept : rt(rt) {
     JS_SetRuntimeOpaque(rt, next_runtime_token());
@@ -550,16 +541,16 @@ Runtime Runtime::create() {
     return Runtime(js_rt);
 }
 
-const Context& Runtime::context(const std::string& name) const {
+Context Runtime::context(const std::string& name) const {
     if(auto it = this->raw->ctxs.find(name); it != this->raw->ctxs.end()) {
-        return it->second;
+        return {it->second->ctx.get()};
     }
 
     auto js_ctx = JS_NewContext(this->js_runtime());
     if(!js_ctx) {
         throw qjs::Exception("Failed to create new JS context");
     }
-    return this->raw->ctxs.emplace(name, Context(js_ctx)).first->second;
+    return this->raw->ctxs.emplace(name, Context::Raw::create(js_ctx)).first->second->ctx.get();
 }
 
 JSRuntime* Runtime::js_runtime() const noexcept {
@@ -573,6 +564,22 @@ Runtime::operator bool() const noexcept {
 Runtime::Runtime(JSRuntime* js_rt) : raw(std::make_unique<Raw>(js_rt)) {}
 
 namespace json {
+std::string stringify(qjs::Value v) {
+    auto ctx = v.context();
+    auto val = v.value();
+    auto json_str_val = qjs::Value{ctx, JS_JSONStringify(ctx, val, JS_UNDEFINED, JS_UNDEFINED)};
+    if(JS_HasException(ctx)) {
+        throw qjs::JSException::dump(ctx);
+    }
+
+    const char* json_cstr = JS_ToCString(ctx, json_str_val.value());
+    if(json_cstr) {
+        std::string result{json_cstr};
+        JS_FreeCString(ctx, json_cstr);
+        return result;
+    }
+    throw qjs::TypeException("Failed to convert value to JSON string");
+};
 
 qjs::Value parse(const std::string& json_str, const Context& ctx) {
     auto ret = qjs::Value{

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -462,6 +462,16 @@ std::vector<CModule::kv>& CModule::exports_list() const noexcept {
 
 Context::Raw::Raw(JSContext* ctx) : ctx(ctx) {}
 
+std::unique_ptr<Context::Raw> Context::Raw::create(JSContext* ctx) noexcept {
+    auto ret = std::make_unique<Raw>(ctx);
+    JS_SetContextOpaque(ctx, ret.get());
+    return ret;
+}
+
+Context::Raw* Context::Raw::from(JSContext* ctx) noexcept {
+    return static_cast<Context::Raw*>(JS_GetContextOpaque(ctx));
+}
+
 void Context::Raw::JSContextDeleter::operator() (JSContext* ctx) const noexcept {
     JS_FreeContext(ctx);
 }
@@ -555,6 +565,71 @@ Context Runtime::context(const std::string& name) const {
 
 JSRuntime* Runtime::js_runtime() const noexcept {
     return this->raw->rt.get();
+}
+
+void Runtime::set_module_loader(std::unique_ptr<ModuleLoader> loader) const noexcept {
+    this->raw->module_loader = std::move(loader);
+
+    return JS_SetModuleLoaderFunc(
+        this->js_runtime(),
+        [](JSContext* ctx, const char* module_base_name, const char* module_name, void* opaque)
+            -> char* {
+            auto raw = static_cast<Raw*>(opaque);
+            assert(raw && raw->module_loader && "Module loader is not set");
+            try {
+                auto normalized_name =
+                    raw->module_loader->normalizer(module_base_name, module_name);
+
+                return js_strdup(ctx, normalized_name.c_str());
+            } catch(const std::exception& e) {
+                JS_ThrowInternalError(ctx, "Exception in module normalizer: %s", e.what());
+                return nullptr;
+            } catch(...) {
+                JS_ThrowInternalError(ctx, "Unknown exception in module normalizer");
+                return nullptr;
+            }
+        },
+        [](JSContext* js_ctx, const char* module_name, void* opaque) -> JSModuleDef* {
+            auto ctx = Context{js_ctx};
+            auto raw = static_cast<Raw*>(opaque);
+            assert(raw && raw->module_loader && "Module loader is not set");
+
+            try {
+                auto source = raw->module_loader->loader(module_name);
+
+                auto module_value = ctx.eval(source.c_str(),
+                                             source.size(),
+                                             module_name,
+                                             JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+
+                if(module_value.is_exception())
+                    return NULL;
+
+                return (JSModuleDef*)JS_VALUE_GET_PTR(module_value.value());
+            } catch(const std::exception& e) {
+                JS_ThrowInternalError(js_ctx, "Exception in module loader: %s", e.what());
+                return nullptr;
+            } catch(...) {
+                JS_ThrowInternalError(js_ctx, "Unknown exception in module loader");
+                return nullptr;
+            }
+        },
+        this->raw.get());
+}
+
+std::expected<bool, Value> Runtime::execute_pending_job() const noexcept {
+    JSContext* ctx = nullptr;
+    switch(JS_ExecutePendingJob(this->js_runtime(), &ctx)) {
+        case 1: return true;
+        case 0: return false;
+        case -1:
+            if(ctx) {
+                return std::unexpected(Value{ctx, JS_GetException(ctx)});
+            } else {
+                return std::unexpected(Value{});
+            }
+        default: return std::unexpected(Value{});
+    }
 }
 
 Runtime::operator bool() const noexcept {

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -590,17 +590,18 @@ void Runtime::set_module_loader(std::unique_ptr<ModuleLoader> loader) const noex
             }
         },
         [](JSContext* js_ctx, const char* module_name, void* opaque) -> JSModuleDef* {
-            auto ctx = Context{js_ctx};
             auto raw = static_cast<Raw*>(opaque);
             assert(raw && raw->module_loader && "Module loader is not set");
 
             try {
                 auto source = raw->module_loader->loader(module_name);
 
-                auto module_value = ctx.eval(source.c_str(),
-                                             source.size(),
-                                             module_name,
-                                             JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+                auto module_value = Value{js_ctx,
+                                          JS_Eval(js_ctx,
+                                                  source.c_str(),
+                                                  source.size(),
+                                                  module_name,
+                                                  JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY)};
 
                 if(module_value.is_exception())
                     return NULL;

--- a/src/catter/core/js/qjs.cc
+++ b/src/catter/core/js/qjs.cc
@@ -603,8 +603,9 @@ void Runtime::set_module_loader(std::unique_ptr<ModuleLoader> loader) const noex
                                                   module_name,
                                                   JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY)};
 
-                if(module_value.is_exception())
-                    return NULL;
+                if(module_value.is_exception()) {
+                    return nullptr;
+                }
 
                 return (JSModuleDef*)JS_VALUE_GET_PTR(module_value.value());
             } catch(const std::exception& e) {

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1493,7 +1493,7 @@ private:
         std::unordered_map<std::string, CModule> modules{};
     };
 
-    JSContext* ctx;
+    JSContext* ctx = nullptr;
 };
 
 /**

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -1475,15 +1475,9 @@ private:
         ~Raw() = default;
 
     public:
-        static std::unique_ptr<Raw> create(JSContext* ctx) {
-            auto ret = std::make_unique<Raw>(ctx);
-            JS_SetContextOpaque(ctx, ret.get());
-            return ret;
-        }
+        static std::unique_ptr<Raw> create(JSContext* ctx) noexcept;
 
-        static Raw* from(JSContext* ctx) noexcept {
-            return static_cast<Raw*>(JS_GetContextOpaque(ctx));
-        }
+        static Raw* from(JSContext* ctx) noexcept;
 
         struct JSContextDeleter {
             void operator() (JSContext* ctx) const noexcept;
@@ -1533,55 +1527,7 @@ public:
      * Install or replace this runtime's JavaScript module loader.
      * The callbacks are retained by the runtime and used by subsequent module evaluations.
      */
-    void set_module_loader(std::unique_ptr<ModuleLoader> loader) const noexcept {
-        this->raw->module_loader = std::move(loader);
-
-        return JS_SetModuleLoaderFunc(
-            this->js_runtime(),
-            [](JSContext* ctx, const char* module_base_name, const char* module_name, void* opaque)
-                -> char* {
-                auto raw = static_cast<Raw*>(opaque);
-                assert(raw && raw->module_loader && "Module loader is not set");
-                try {
-                    auto normalized_name =
-                        raw->module_loader->normalizer(module_base_name, module_name);
-
-                    return js_strdup(ctx, normalized_name.c_str());
-                } catch(const std::exception& e) {
-                    JS_ThrowInternalError(ctx, "Exception in module normalizer: %s", e.what());
-                    return nullptr;
-                } catch(...) {
-                    JS_ThrowInternalError(ctx, "Unknown exception in module normalizer");
-                    return nullptr;
-                }
-            },
-            [](JSContext* js_ctx, const char* module_name, void* opaque) -> JSModuleDef* {
-                auto ctx = Context{js_ctx};
-                auto raw = static_cast<Raw*>(opaque);
-                assert(raw && raw->module_loader && "Module loader is not set");
-
-                try {
-                    auto source = raw->module_loader->loader(module_name);
-
-                    auto module_value = ctx.eval(source.c_str(),
-                                                 source.size(),
-                                                 module_name,
-                                                 JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-
-                    if(module_value.is_exception())
-                        return NULL;
-
-                    return (JSModuleDef*)JS_VALUE_GET_PTR(module_value.value());
-                } catch(const std::exception& e) {
-                    JS_ThrowInternalError(js_ctx, "Exception in module loader: %s", e.what());
-                    return nullptr;
-                } catch(...) {
-                    JS_ThrowInternalError(js_ctx, "Unknown exception in module loader");
-                    return nullptr;
-                }
-            },
-            this->raw.get());
-    }
+    void set_module_loader(std::unique_ptr<ModuleLoader> loader) const noexcept;
 
     bool has_job_pending() const noexcept {
         return JS_IsJobPending(this->js_runtime());
@@ -1592,20 +1538,7 @@ public:
      * @return std::expected<bool, Value> Returns true if a job was executed, false if no jobs were
      * pending, or std::unexpected(Value) if an exception occurred.
      */
-    std::expected<bool, Value> execute_pending_job() const noexcept {
-        JSContext* ctx = nullptr;
-        switch(JS_ExecutePendingJob(this->js_runtime(), &ctx)) {
-            case 1: return true;
-            case 0: return false;
-            case -1:
-                if(ctx) {
-                    return std::unexpected(Value{ctx, JS_GetException(ctx)});
-                } else {
-                    return std::unexpected(Value{});
-                }
-            default: return std::unexpected(Value{});
-        }
-    }
+    std::expected<bool, Value> execute_pending_job() const noexcept;
 
     operator bool() const noexcept;
 

--- a/src/catter/core/js/qjs.h
+++ b/src/catter/core/js/qjs.h
@@ -27,18 +27,7 @@
 
 namespace catter::qjs {
 
-namespace refl = kota::meta;
-
-namespace json {
-
-template <typename T>
-    requires requires(T&& t) {
-        { t.value() } -> std::convertible_to<JSValue>;
-        { t.context() } -> std::convertible_to<JSContext*>;
-    }
-std::string stringify(T&& v);
-
-}  // namespace json
+namespace meta = kota::meta;
 
 namespace detail {
 
@@ -481,7 +470,7 @@ public:
             id = it->second.id;
         } else {
             auto class_name =
-                std::format("qjs.{}", std::string_view{refl::type_name<Invocable&&>()});
+                std::format("qjs.{}", std::string_view{meta::type_name<Invocable&&>()});
             if constexpr(std::is_lvalue_reference_v<Invocable&&>) {
                 JSClassDef def{class_name.c_str(),
                                nullptr,
@@ -682,7 +671,7 @@ public:
             id = it->second.id;
         } else {
             auto class_name =
-                std::format("qjs.{}", std::string_view{refl::type_name<Invocable&&>()});
+                std::format("qjs.{}", std::string_view{meta::type_name<Invocable&&>()});
             if constexpr(std::is_lvalue_reference_v<Invocable&&>) {
                 JSClassDef def{class_name.c_str(),
                                nullptr,
@@ -1398,6 +1387,7 @@ class Context {
 public:
     friend class Runtime;
 
+    Context(JSContext* js_ctx) noexcept;
     Context() = default;
     Context(const Context&) = delete;
     Context(Context&&) = default;
@@ -1485,6 +1475,16 @@ private:
         ~Raw() = default;
 
     public:
+        static std::unique_ptr<Raw> create(JSContext* ctx) {
+            auto ret = std::make_unique<Raw>(ctx);
+            JS_SetContextOpaque(ctx, ret.get());
+            return ret;
+        }
+
+        static Raw* from(JSContext* ctx) noexcept {
+            return static_cast<Raw*>(JS_GetContextOpaque(ctx));
+        }
+
         struct JSContextDeleter {
             void operator() (JSContext* ctx) const noexcept;
         };
@@ -1493,13 +1493,7 @@ private:
         std::unordered_map<std::string, CModule> modules{};
     };
 
-    void set_opaque() noexcept;
-
-    static Raw* get_opaque(JSContext* ctx) noexcept;
-
-    Context(JSContext* js_ctx) noexcept;
-
-    std::unique_ptr<Raw> raw = nullptr;
+    JSContext* ctx;
 };
 
 /**
@@ -1531,7 +1525,7 @@ public:
 
     // Get or create a context with the given name
     // @name: The name of the context. Just for identification purposes.
-    const Context& context(const std::string& name = "default") const;
+    Context context(const std::string& name = "default") const;
 
     JSRuntime* js_runtime() const noexcept;
 
@@ -1561,29 +1555,28 @@ public:
                     return nullptr;
                 }
             },
-            [](JSContext* ctx, const char* module_name, void* opaque) -> JSModuleDef* {
+            [](JSContext* js_ctx, const char* module_name, void* opaque) -> JSModuleDef* {
+                auto ctx = Context{js_ctx};
                 auto raw = static_cast<Raw*>(opaque);
                 assert(raw && raw->module_loader && "Module loader is not set");
 
                 try {
                     auto source = raw->module_loader->loader(module_name);
-                    auto module_value =
-                        Value{ctx,
-                              JS_Eval(ctx,
-                                      source.data(),
-                                      source.size(),
-                                      module_name,
-                                      JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY)};
+
+                    auto module_value = ctx.eval(source.c_str(),
+                                                 source.size(),
+                                                 module_name,
+                                                 JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
 
                     if(module_value.is_exception())
                         return NULL;
 
                     return (JSModuleDef*)JS_VALUE_GET_PTR(module_value.value());
                 } catch(const std::exception& e) {
-                    JS_ThrowInternalError(ctx, "Exception in module loader: %s", e.what());
+                    JS_ThrowInternalError(js_ctx, "Exception in module loader: %s", e.what());
                     return nullptr;
                 } catch(...) {
-                    JS_ThrowInternalError(ctx, "Unknown exception in module loader");
+                    JS_ThrowInternalError(js_ctx, "Unknown exception in module loader");
                     return nullptr;
                 }
             },
@@ -1637,7 +1630,7 @@ private:
 
         std::unique_ptr<ModuleLoader> module_loader = nullptr;
         std::unique_ptr<JSRuntime, JSRuntimeDeleter> rt = nullptr;
-        std::unordered_map<std::string, Context> ctxs{};
+        std::unordered_map<std::string, std::unique_ptr<Context::Raw>> ctxs{};
     };
 
     Runtime(JSRuntime* js_rt);
@@ -1647,27 +1640,16 @@ private:
 
 namespace json {
 
+std::string stringify(qjs::Value v);
+
 template <typename T>
     requires requires(T&& t) {
         { t.value() } -> std::convertible_to<JSValue>;
         { t.context() } -> std::convertible_to<JSContext*>;
     }
 std::string stringify(T&& v) {
-    auto ctx = v.context();
-    auto val = v.value();
-    auto json_str_val = qjs::Value{ctx, JS_JSONStringify(ctx, val, JS_UNDEFINED, JS_UNDEFINED)};
-    if(JS_HasException(ctx)) {
-        throw qjs::JSException::dump(ctx);
-    }
-
-    const char* json_cstr = JS_ToCString(ctx, json_str_val.value());
-    if(json_cstr) {
-        std::string result{json_cstr};
-        JS_FreeCString(ctx, json_cstr);
-        return result;
-    }
-    throw qjs::TypeException("Failed to convert value to JSON string");
-};
+    return stringify(qjs::Value{v.context(), v.value()});
+}
 
 qjs::Value parse(const std::string& json_str, const Context& ctx);
 }  // namespace json

--- a/tests/unit/catter/core/js/type.cc
+++ b/tests/unit/catter/core/js/type.cc
@@ -23,7 +23,7 @@ TEST_SUITE(api_tests) {
 TEST_CASE(catter_runtime_conversion) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         js::CatterRuntime catter_runtime{
             .supportActions = {js::ActionType::skip, js::ActionType::modify},
@@ -40,7 +40,7 @@ TEST_CASE(catter_runtime_conversion) {
 TEST_CASE(command_data_and_action_conversion) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         js::CommandData command_data{
             .cwd = "D:/Code/hook/catter",
@@ -70,7 +70,7 @@ TEST_CASE(command_data_and_action_conversion) {
 TEST_CASE(process_result_and_config_conversion) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         js::ProcessResult process_result{
             .code = 0,
@@ -100,7 +100,7 @@ TEST_CASE(process_result_and_config_conversion) {
 TEST_CASE(option_item_and_info_conversion) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         js::OptionItem option_item{
             .values = {"include"},

--- a/tests/unit/catter/core/qjs.cc
+++ b/tests/unit/catter/core/qjs.cc
@@ -109,9 +109,9 @@ TEST_CASE(runtime_context_and_eval_cover_success_and_error_paths) {
         auto runtime = qjs::Runtime::create();
         EXPECT_TRUE(runtime);
 
-        auto& default_ctx = runtime.context();
-        auto& same_ctx = runtime.context();
-        auto& other_ctx = runtime.context("other");
+        auto default_ctx = runtime.context();
+        auto same_ctx = runtime.context();
+        auto other_ctx = runtime.context("other");
 
         EXPECT_TRUE(default_ctx.js_context() == same_ctx.js_context());
         EXPECT_TRUE(default_ctx.js_context() != other_ctx.js_context());
@@ -142,7 +142,7 @@ TEST_CASE(runtime_context_and_eval_cover_success_and_error_paths) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
     EXPECT_TRUE(throws_with_message(
         [&]() { ctx.eval("throw new TypeError('boom')", "<eval>", eval_flags); },
         "TypeError"));
@@ -152,7 +152,7 @@ TEST_CASE(runtime_context_and_eval_cover_success_and_error_paths) {
 TEST_CASE(value_conversions_cover_supported_types_copy_move_and_type_mismatch) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto bool_value = qjs::Value::from(ctx.js_context(), true);
         auto signed_value = qjs::Value::from(ctx.js_context(), int64_t{-7});
@@ -183,7 +183,7 @@ TEST_CASE(value_conversions_cover_supported_types_copy_move_and_type_mismatch) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
     auto bool_value = qjs::Value::from(ctx.js_context(), true);
     EXPECT_FALSE(bool_value.to<std::string>().has_value());
     EXPECT_TRUE(throws_with_message([&]() { (void)bool_value.as<std::string>(); },
@@ -192,7 +192,7 @@ TEST_CASE(value_conversions_cover_supported_types_copy_move_and_type_mismatch) {
 
 TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
     auto global = ctx.global_this();
 
     constexpr std::string_view sync_source = "globalThis.syncResult = 40 + 2;";
@@ -249,7 +249,7 @@ TEST_CASE(script_and_module_evaluation_cover_sync_async_and_custom_loading) {
 TEST_CASE(object_property_apis_cover_reads_writes_and_exceptional_access) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto object = qjs::json::parse(R"({"existing":1})", ctx).as<qjs::Object>();
 
@@ -276,7 +276,7 @@ TEST_CASE(object_property_apis_cover_reads_writes_and_exceptional_access) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
     auto throwing_object =
         ctx.eval(
                "Object.defineProperty({}, 'boom', { get() { throw new Error('property boom'); } })",
@@ -293,7 +293,7 @@ TEST_CASE(object_property_apis_cover_reads_writes_and_exceptional_access) {
 TEST_CASE(array_conversions_cover_roundtrip_element_failures_and_push_errors) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto values = std::vector<int64_t>{1, 2, 3};
         auto array = qjs::Array<int64_t>::from(ctx.js_context(), values);
@@ -318,7 +318,7 @@ TEST_CASE(array_conversions_cover_roundtrip_element_failures_and_push_errors) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
 
     auto not_an_array = qjs::json::parse(R"({"length":1})", ctx).as<qjs::Object>();
     EXPECT_TRUE(throws_with_message([&]() { (void)not_an_array.as<qjs::Array<int64_t>>(); },
@@ -334,7 +334,7 @@ TEST_CASE(array_conversions_cover_roundtrip_element_failures_and_push_errors) {
 TEST_CASE(array_conversions_cover_string_roundtrip) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto string_values = std::vector<std::string>{"alpha", "beta", "gamma"};
         auto string_array = qjs::Array<std::string>::from(ctx.js_context(), string_values);
@@ -353,7 +353,7 @@ TEST_CASE(array_conversions_cover_string_roundtrip) {
 TEST_CASE(function_wrappers_cover_cpp_js_and_raw_function_invocation) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
         int64_t remembered = 0;
 
         auto plus_three =
@@ -419,7 +419,7 @@ TEST_CASE(function_wrappers_cover_cpp_js_and_raw_function_invocation) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
     auto zero_arg_js_function =
         ctx.eval("(function () { return 7; })", "<eval>", eval_flags).as<qjs::Object>();
     EXPECT_TRUE(throws_with_message(
@@ -439,7 +439,7 @@ TEST_CASE(function_wrappers_cover_cpp_js_and_raw_function_invocation) {
 
 TEST_CASE(function_wrappers_surface_argument_and_exception_failures) {
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
 
     auto expect_number = qjs::Function<int64_t(int64_t)>::from(ctx.js_context(),
                                                                [](int64_t value) { return value; });
@@ -468,7 +468,7 @@ TEST_CASE(function_wrappers_surface_argument_and_exception_failures) {
 
 TEST_CASE(function_wrappers_cover_lvalue_functor_storage) {
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
 
     CountingFunctor counting_functor{};
     auto lvalue_functor = qjs::Function<int64_t(int64_t)>::from(ctx.js_context(), counting_functor);
@@ -488,7 +488,7 @@ TEST_CASE(function_wrappers_cover_lvalue_functor_storage) {
 TEST_CASE(function_wrappers_cover_variadic_parameter_list_api) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto sum_all = qjs::Function<int64_t(qjs::Parameters)>::from(ctx.js_context(),
                                                                      [](qjs::Parameters args) {
@@ -550,7 +550,7 @@ TEST_CASE(function_wrappers_cover_variadic_parameter_list_api) {
     EXPECT_NOTHROWS(f());
 
     auto runtime = qjs::Runtime::create();
-    auto& ctx = runtime.context();
+    auto ctx = runtime.context();
 
     auto plain_object = qjs::json::parse(R"({"value":1})", ctx).as<qjs::Object>();
     EXPECT_TRUE(throws_with_message(
@@ -574,7 +574,7 @@ TEST_CASE(function_wrappers_cover_variadic_parameter_list_api) {
 TEST_CASE(error_and_json_helpers_cover_metadata_stringify_and_invalid_variadic_args) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto error = ctx.eval("new TypeError('boom')", "<eval>", eval_flags)
                          .as<qjs::Object>()
@@ -608,9 +608,9 @@ TEST_CASE(error_and_json_helpers_cover_metadata_stringify_and_invalid_variadic_a
 
 TEST_CASE(object_register_reuses_class_id_per_runtime_and_separates_runtimes) {
     auto runtime_a = qjs::Runtime::create();
-    auto& ctx_a = runtime_a.context();
+    auto ctx_a = runtime_a.context();
     auto runtime_b = qjs::Runtime::create();
-    auto& ctx_b = runtime_b.context();
+    auto ctx_b = runtime_b.context();
 
     using Register = qjs::Object::Register<IncrementFunctor&&>;
 
@@ -644,7 +644,7 @@ TEST_CASE(object_register_reuses_class_id_per_runtime_and_separates_runtimes) {
 TEST_CASE(cmodule_exports_cover_functor_export_bare_export_and_module_cache) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto& module = ctx.cmodule("native-test");
         auto& same_module = ctx.cmodule("native-test");
@@ -675,7 +675,7 @@ TEST_CASE(cmodule_exports_cover_functor_export_bare_export_and_module_cache) {
 TEST_CASE(promise_capability_and_then_cover_fulfilled_and_rejected_paths) {
     auto f = [&]() {
         auto runtime = qjs::Runtime::create();
-        auto& ctx = runtime.context();
+        auto ctx = runtime.context();
 
         auto fulfilled_cap = qjs::PromiseCapability::create(ctx.js_context());
         auto fulfilled_promise_value = qjs::Value::from(fulfilled_cap.promise);
@@ -743,7 +743,7 @@ TEST_CASE(async_function_wraps_tasks_as_promises) {
     auto f = [&]() {
         auto task = []() -> kota::task<> {
             auto runtime = qjs::Runtime::create();
-            auto& ctx = runtime.context();
+            auto ctx = runtime.context();
             js::JsLoop js_loop;
 
             auto& loop = kota::event_loop::current();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `json::stringify` support for direct JavaScript values.

* **Bug Fixes**
  * Improved JavaScript module evaluation and caching reliability.
  * Strengthened validation around module access and runtime context usage.
  * Enhanced QuickJS error handling during module loading and JSON conversion.

* **Tests**
  * Updated JavaScript/type conversion tests to use the revised runtime context handling (by value).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->