### PR TITLE
ci: use CLICE_DOCS token for docs sync

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: clice-io/docs@main
         with:
           project: catter
-          token: ${{ secrets.PUBLISH_DOCS }}
+          token: ${{ secrets.CLICE_DOCS }}


### PR DESCRIPTION
The docs-sync secret was recreated org-level under the name CLICE_DOCS (owned by the clice-bot account), replacing PUBLISH_DOCS.